### PR TITLE
EPG streaming and channel table

### DIFF
--- a/app/src/main/java/com/supernova/data/dao/ChannelDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/ChannelDao.kt
@@ -1,0 +1,20 @@
+package com.supernova.data.dao
+
+import androidx.room.*
+import com.supernova.data.entities.ChannelEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ChannelDao {
+    @Query("SELECT * FROM channel ORDER BY channel_id ASC")
+    fun getAllChannels(): Flow<List<ChannelEntity>>
+
+    @Query("SELECT * FROM channel WHERE channel_id = :channelId")
+    suspend fun getChannelById(channelId: String): ChannelEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertChannels(channels: List<ChannelEntity>)
+
+    @Query("DELETE FROM channel")
+    suspend fun deleteAllChannels()
+}

--- a/app/src/main/java/com/supernova/data/dao/EpgDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/EpgDao.kt
@@ -2,12 +2,18 @@ package com.supernova.data.dao
 
 import androidx.room.*
 import com.supernova.data.entities.EpgEntity
+import com.supernova.data.entities.EpgWithChannel
 import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface EpgDao {
-    @Query("SELECT * FROM epg WHERE channel_id = :channelId ORDER BY start ASC")
-    fun getProgramsForChannel(channelId: Int): Flow<List<EpgEntity>>
+    @Query("""
+        SELECT e.*, c.name FROM epg e
+        INNER JOIN channel c ON e.channel_id = c.channel_id
+        WHERE e.channel_id = :channelId
+        ORDER BY e.start ASC
+    """)
+    fun getProgramsForChannel(channelId: String): Flow<List<EpgWithChannel>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertPrograms(programs: List<EpgEntity>)
@@ -16,5 +22,5 @@ interface EpgDao {
     suspend fun deleteAllPrograms()
 
     @Query("DELETE FROM epg WHERE channel_id = :channelId")
-    suspend fun deleteProgramsForChannel(channelId: Int)
+    suspend fun deleteProgramsForChannel(channelId: String)
 }

--- a/app/src/main/java/com/supernova/data/database/SuperNovaDatabase.kt
+++ b/app/src/main/java/com/supernova/data/database/SuperNovaDatabase.kt
@@ -12,6 +12,7 @@ import com.supernova.data.dao.MovieDao
 import com.supernova.data.dao.LiveTvDao
 import com.supernova.data.dao.SeriesDao
 import com.supernova.data.dao.EpgDao
+import com.supernova.data.dao.ChannelDao
 import com.supernova.data.entities.ProfileEntity
 import com.supernova.data.entities.CategoryEntity
 import com.supernova.data.entities.MovieEntity
@@ -20,6 +21,7 @@ import com.supernova.data.entities.LiveTvEntity
 import com.supernova.data.entities.SeriesEntity
 import com.supernova.data.entities.SeriesCategoryEntity
 import com.supernova.data.entities.EpgEntity
+import com.supernova.data.entities.ChannelEntity
 import com.supernova.network.AvatarService
 
 @Database(
@@ -31,9 +33,10 @@ import com.supernova.network.AvatarService
         LiveTvEntity::class,
         SeriesEntity::class,
         SeriesCategoryEntity::class,
+        ChannelEntity::class,
         EpgEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 abstract class SupernovaDatabase : RoomDatabase() {
@@ -43,6 +46,7 @@ abstract class SupernovaDatabase : RoomDatabase() {
     abstract fun movieDao(): MovieDao
     abstract fun liveTvDao(): LiveTvDao
     abstract fun seriesDao(): SeriesDao
+    abstract fun channelDao(): ChannelDao
     abstract fun epgDao(): EpgDao
 
     companion object {

--- a/app/src/main/java/com/supernova/data/entities/ChannelEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/ChannelEntity.kt
@@ -1,0 +1,11 @@
+package com.supernova.data.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "channel")
+data class ChannelEntity(
+    @PrimaryKey
+    val channel_id: String,
+    val name: String?
+)

--- a/app/src/main/java/com/supernova/data/entities/EpgEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/EpgEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.supernova.data.entities.ChannelEntity
 
 @Entity(
     tableName = "epg",
@@ -11,11 +12,10 @@ import androidx.room.PrimaryKey
         Index("start"),
         Index("end"),
         Index("channel_id"),
-        Index("channel_name")
     ],
     foreignKeys = [
         ForeignKey(
-            entity = LiveTvEntity::class,
+            entity = ChannelEntity::class,
             parentColumns = ["channel_id"],
             childColumns = ["channel_id"],
             onDelete = ForeignKey.CASCADE
@@ -25,8 +25,7 @@ import androidx.room.PrimaryKey
 data class EpgEntity(
     @PrimaryKey(autoGenerate = true)
     val id: Int = 0,
-    val channel_id: Int,
-    val channel_name: String?,
+    val channel_id: String,
     val start: Long,
     val end: Long,
     val title: String?,

--- a/app/src/main/java/com/supernova/data/entities/EpgWithChannel.kt
+++ b/app/src/main/java/com/supernova/data/entities/EpgWithChannel.kt
@@ -1,0 +1,9 @@
+package com.supernova.data.entities
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+
+data class EpgWithChannel(
+    @Embedded val epg: EpgEntity,
+    @ColumnInfo(name = "name") val channel_name: String?
+)

--- a/app/src/main/java/com/supernova/network/DataSyncService.kt
+++ b/app/src/main/java/com/supernova/network/DataSyncService.kt
@@ -16,7 +16,6 @@ import org.xmlpull.v1.XmlPullParser
 import android.util.Xml
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonToken
-import java.io.StringReader
 import java.text.SimpleDateFormat
 import java.util.Locale
 import com.supernova.utils.SecureDataStore
@@ -106,58 +105,73 @@ class DataSyncService(
     }
 // In DataSyncService.kt
 
-    private suspend fun streamXmltvBatched(
+    private suspend fun batchXmlStream(
         responseBody: ResponseBody,
         batchSize: Int = DEFAULT_BATCH_SIZE,
-        insertBatch: suspend (List<EpgEntity>) -> Unit
-    ): Int {
+        insertChannels: suspend (List<ChannelEntity>) -> Unit,
+        insertPrograms: suspend (List<EpgEntity>) -> Unit
+    ) {
         val parser = Xml.newPullParser().apply {
             setInput(responseBody.byteStream(), null)
         }
 
         var event = parser.eventType
-        var current: EpgEntity? = null
-        val batch = mutableListOf<EpgEntity>()
-        var total = 0
+        var currentProgram: EpgEntity? = null
+        var currentChannelId: String? = null
+        var currentChannelName: String? = null
+        val programBatch = mutableListOf<EpgEntity>()
+        val channelBatch = mutableListOf<ChannelEntity>()
 
         while (event != XmlPullParser.END_DOCUMENT) {
             when (event) {
-                XmlPullParser.START_TAG -> {
-                    when (parser.name) {
-                        "programme" -> {
-                            // start a new programme
-                            val channelId =
-                                parser.getAttributeValue(null, "channel")?.toIntOrNull() ?: 0
-                            val start = parseXmlTvTime(parser.getAttributeValue(null, "start"))
-                            val end = parseXmlTvTime(parser.getAttributeValue(null, "stop"))
-                            current = if (start != null && end != null) {
-                                EpgEntity(
-                                    channel_id = channelId, channel_name = null,
-                                    start = start, end = end,
-                                    title = null, description = null
-                                )
-                            } else null
-                        }
-
-                        "title" -> {
-                            current = current?.copy(title = parser.nextText())
-                        }
-
-                        "desc" -> {
-                            current = current?.copy(description = parser.nextText())
-                        }
+                XmlPullParser.START_TAG -> when (parser.name) {
+                    "channel" -> {
+                        currentChannelId = parser.getAttributeValue(null, "id")
+                        currentChannelName = null
                     }
+                    "display-name" -> if (currentChannelId != null) {
+                        currentChannelName = parser.nextText()
+                    }
+                    "programme" -> {
+                        val ch = parser.getAttributeValue(null, "channel") ?: ""
+                        val start = parseXmlTvTime(parser.getAttributeValue(null, "start"))
+                        val end = parseXmlTvTime(parser.getAttributeValue(null, "stop"))
+                        currentProgram = if (start != null && end != null) {
+                            EpgEntity(
+                                channel_id = ch,
+                                start = start,
+                                end = end,
+                                title = null,
+                                description = null
+                            )
+                        } else null
+                    }
+                    "title" -> currentProgram = currentProgram?.copy(title = parser.nextText())
+                    "desc" -> currentProgram = currentProgram?.copy(description = parser.nextText())
                 }
 
-                XmlPullParser.END_TAG -> {
-                    if (parser.name == "programme" && current != null) {
-                        batch += current
-                        total++
-                        current = null
+                XmlPullParser.END_TAG -> when (parser.name) {
+                    "channel" -> {
+                        currentChannelId?.let { id ->
+                            channelBatch += ChannelEntity(id, currentChannelName)
+                            currentChannelId = null
+                            currentChannelName = null
 
-                        if (batch.size >= batchSize) {
-                            insertBatch(batch.toList())
-                            batch.clear()
+                            if (channelBatch.size >= batchSize) {
+                                insertChannels(channelBatch.toList())
+                                channelBatch.clear()
+                            }
+                        }
+                    }
+                    "programme" -> {
+                        currentProgram?.let { prog ->
+                            programBatch += prog
+                            currentProgram = null
+
+                            if (programBatch.size >= batchSize) {
+                                insertPrograms(programBatch.toList())
+                                programBatch.clear()
+                            }
                         }
                     }
                 }
@@ -165,12 +179,8 @@ class DataSyncService(
             event = parser.next()
         }
 
-        // flush remainder
-        if (batch.isNotEmpty()) {
-            insertBatch(batch)
-        }
-
-        return total
+        if (channelBatch.isNotEmpty()) insertChannels(channelBatch)
+        if (programBatch.isNotEmpty()) insertPrograms(programBatch)
     }
 
 
@@ -265,11 +275,11 @@ class DataSyncService(
         val epgUrl = "$portal/xmltv.php"
         val resp = apiService.downloadEpg(epgUrl, username, password)
         if (!resp.isSuccessful) throw Exception("EPG download failed ${resp.code()}")
-        val xml = resp.body()?.string() ?: ""
-        val programs = parseEpg(xml)
+        val body = resp.body() ?: throw Exception("Empty EPG body")
         database.withTransaction {
             database.epgDao().deleteAllPrograms()
-            if (programs.isNotEmpty()) database.epgDao().insertPrograms(programs)
+            database.channelDao().deleteAllChannels()
+            batchXmlStream(body, insertChannels = { database.channelDao().insertChannels(it) }, insertPrograms = { database.epgDao().insertPrograms(it) })
         }
     }
 
@@ -328,7 +338,7 @@ class DataSyncService(
 
             emit(SyncResult.Progress("Syncing EPG...", 4, 7))
             try {
-
+                syncEPG(apiService, portal, username, password)
             } catch (e: Exception) {
                 emit(SyncResult.Error("EPG sync failed: ${e.message}"))
                 return@flow
@@ -602,49 +612,6 @@ class DataSyncService(
         return seriesEntities to seriesCategoryEntities
     }
 
-    private fun parseEpg(xml: String): List<EpgEntity> {
-        val programs = mutableListOf<EpgEntity>()
-        try {
-            val parser = Xml.newPullParser()
-            parser.setInput(StringReader(xml))
-            var event = parser.eventType
-            var current: EpgEntity? = null
-            while (event != XmlPullParser.END_DOCUMENT) {
-                when (event) {
-                    XmlPullParser.START_TAG -> {
-                        when (parser.name) {
-                            "programme" -> {
-                                val start = parseXmlTvTime(parser.getAttributeValue(null, "start"))
-                                val end = parseXmlTvTime(parser.getAttributeValue(null, "stop"))
-                                val channel = parser.getAttributeValue(null, "channel")
-                                current = if (start != null && end != null) {
-                                    EpgEntity(
-                                        channel_id = channel?.toIntOrNull() ?: 0,
-                                        channel_name = channel,
-                                        start = start,
-                                        end = end,
-                                        title = null,
-                                        description = null
-                                    )
-                                } else null
-                            }
-
-                            "title" -> current = current?.copy(title = parser.nextText())
-                            "desc" -> current = current?.copy(description = parser.nextText())
-                        }
-                    }
-
-                    XmlPullParser.END_TAG -> if (parser.name == "programme") {
-                        current?.let { programs.add(it) }
-                    }
-                }
-                event = parser.next()
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Failed to parse EPG", e)
-        }
-        return programs
-    }
 
     private fun parseXmlTvTime(value: String?): Long? {
         return try {


### PR DESCRIPTION
## Summary
- stream XMLTV directly from network using `batchXmlStream`
- store EPG channel info in a new `ChannelEntity`
- remove `channel_name` from `EpgEntity` and join with channels through `EpgDao`
- add `ChannelDao` and update database schema to version 5
- wire new EPG sync logic into `DataSyncService`

## Testing
- `./gradlew test --no-daemon` *(fails to run to completion in container)*

------
https://chatgpt.com/codex/tasks/task_e_68717284bab483339541b69b5498638b