### PR TITLE
Switch to DML versioning for IPTV sync

### DIFF
--- a/app/src/main/java/com/supernova/data/dao/CategoryDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/CategoryDao.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface CategoryDao {
 
-    @Query("SELECT * FROM category WHERE type = :type ORDER BY name ASC")
+    @Query("SELECT * FROM category WHERE type = :type AND is_live = 1 ORDER BY name ASC")
     fun getCategoriesByType(type: String): Flow<List<CategoryEntity>>
 
     @Query("SELECT * FROM category WHERE type = :type AND parent_id = :parentId ORDER BY name ASC")
@@ -39,4 +39,30 @@ interface CategoryDao {
 
     @Query("SELECT COUNT(*) FROM category WHERE type = :type")
     suspend fun getCategoryCount(type: String): Int
+
+    // --- DML versioning helpers ---
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertCategoriesStaging(categories: List<CategoryEntity>)
+
+    @Query(
+        "INSERT INTO category(type, id, name, parent_id, is_live) " +
+            "SELECT type, id, name, parent_id, 0 FROM category " +
+            "WHERE type = :type AND (:categoryId IS NULL OR id = :categoryId) AND is_live = 1"
+    )
+    suspend fun copyFromLive(type: String, categoryId: Int?)
+
+    @Query("DELETE FROM category WHERE is_live = 0")
+    suspend fun deleteStaging()
+
+    @Query("DELETE FROM category WHERE is_live = 1")
+    suspend fun deleteLive()
+
+    @Query("UPDATE category SET is_live = 1 WHERE is_live = 0")
+    suspend fun promoteStaging()
+
+    @Transaction
+    suspend fun swapStagingToLive() {
+        deleteLive()
+        promoteStaging()
+    }
 }

--- a/app/src/main/java/com/supernova/data/dao/CategoryDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/CategoryDao.kt
@@ -51,6 +51,9 @@ interface CategoryDao {
     )
     suspend fun copyFromLive(type: String, categoryId: Int?)
 
+    @Query("DELETE FROM category WHERE type = :type AND id = :categoryId AND is_live = 0")
+    suspend fun deleteStagingCategory(type: String, categoryId: Int)
+
     @Query("DELETE FROM category WHERE is_live = 0")
     suspend fun deleteStaging()
 

--- a/app/src/main/java/com/supernova/data/dao/LiveTvDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/LiveTvDao.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface LiveTvDao {
 
-    @Query("SELECT * FROM live_tv ORDER BY name ASC")
+    @Query("SELECT * FROM live_tv WHERE is_live = 1 ORDER BY name ASC")
     fun getAllChannels(): Flow<List<LiveTvEntity>>
 
     @Query("SELECT * FROM live_tv WHERE channel_id = :channelId")
@@ -15,24 +15,24 @@ interface LiveTvDao {
 
     @Query("""
         SELECT * FROM live_tv 
-        WHERE category_type = :categoryType AND category_id = :categoryId
+        WHERE category_type = :categoryType AND category_id = :categoryId AND is_live = 1
         ORDER BY name ASC
     """)
     fun getChannelsByCategory(categoryType: String, categoryId: Int): Flow<List<LiveTvEntity>>
 
-    @Query("SELECT * FROM live_tv WHERE name LIKE '%' || :searchQuery || '%' ORDER BY name ASC")
+    @Query("SELECT * FROM live_tv WHERE is_live = 1 AND name LIKE '%' || :searchQuery || '%' ORDER BY name ASC")
     fun searchChannels(searchQuery: String): Flow<List<LiveTvEntity>>
 
-    @Query("SELECT * FROM live_tv WHERE tv_archive = 1 ORDER BY name ASC")
+    @Query("SELECT * FROM live_tv WHERE is_live = 1 AND tv_archive = 1 ORDER BY name ASC")
     fun getChannelsWithArchive(): Flow<List<LiveTvEntity>>
 
-    @Query("SELECT * FROM live_tv WHERE epg_channel_id = :epgChannelId")
+    @Query("SELECT * FROM live_tv WHERE epg_channel_id = :epgChannelId AND is_live = 1")
     suspend fun getChannelByEpgId(epgChannelId: String): LiveTvEntity?
 
-    @Query("SELECT * FROM live_tv ORDER BY added DESC LIMIT :limit")
+    @Query("SELECT * FROM live_tv WHERE is_live = 1 ORDER BY added DESC LIMIT :limit")
     fun getRecentlyAddedChannels(limit: Int): Flow<List<LiveTvEntity>>
 
-    @Query("SELECT * FROM live_tv ORDER BY num ASC")
+    @Query("SELECT * FROM live_tv WHERE is_live = 1 ORDER BY num ASC")
     fun getChannelsOrderedByNumber(): Flow<List<LiveTvEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -58,4 +58,30 @@ interface LiveTvDao {
 
     @Query("SELECT COUNT(*) FROM live_tv WHERE category_type = :categoryType AND category_id = :categoryId")
     suspend fun getChannelCountByCategory(categoryType: String, categoryId: Int): Int
+
+    // --- DML versioning helpers ---
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertChannelsStaging(channels: List<LiveTvEntity>)
+
+    @Query(
+        "INSERT INTO live_tv(channel_id, num, name, stream_type, stream_icon, epg_channel_id, added, custom_sid, tv_archive, direct_source, tv_archive_duration, category_type, category_id, thumbnail, is_live) " +
+            "SELECT channel_id, num, name, stream_type, stream_icon, epg_channel_id, added, custom_sid, tv_archive, direct_source, tv_archive_duration, category_type, category_id, thumbnail, 0 FROM live_tv " +
+            "WHERE is_live = 1 AND (:categoryId IS NULL OR category_id = :categoryId)"
+    )
+    suspend fun copyFromLive(categoryId: Int?)
+
+    @Query("DELETE FROM live_tv WHERE is_live = 0")
+    suspend fun deleteStaging()
+
+    @Query("DELETE FROM live_tv WHERE is_live = 1")
+    suspend fun deleteLive()
+
+    @Query("UPDATE live_tv SET is_live = 1 WHERE is_live = 0")
+    suspend fun promoteStaging()
+
+    @Transaction
+    suspend fun swapStagingToLive() {
+        deleteLive()
+        promoteStaging()
+    }
 }

--- a/app/src/main/java/com/supernova/data/dao/LiveTvDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/LiveTvDao.kt
@@ -70,6 +70,9 @@ interface LiveTvDao {
     )
     suspend fun copyFromLive(categoryId: Int?)
 
+    @Query("DELETE FROM live_tv WHERE category_id = :categoryId AND is_live = 0")
+    suspend fun deleteStagingByCategory(categoryId: Int)
+
     @Query("DELETE FROM live_tv WHERE is_live = 0")
     suspend fun deleteStaging()
 

--- a/app/src/main/java/com/supernova/data/dao/MovieDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/MovieDao.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface MovieDao {
 
-    @Query("SELECT * FROM movie ORDER BY name ASC")
+    @Query("SELECT * FROM movie WHERE is_live = 1 ORDER BY name ASC")
     fun getAllMovies(): Flow<List<MovieEntity>>
 
     @Query("SELECT * FROM movie WHERE movie_id = :movieId")
@@ -18,18 +18,18 @@ interface MovieDao {
     @Query("""
         SELECT m.* FROM movie m
         INNER JOIN movie_category mc ON m.movie_id = mc.movie_id
-        WHERE mc.category_type = :categoryType AND mc.category_id = :categoryId
+        WHERE mc.category_type = :categoryType AND mc.category_id = :categoryId AND m.is_live = 1 AND mc.is_live = 1
         ORDER BY m.name ASC
     """)
     fun getMoviesByCategory(categoryType: String, categoryId: Int): Flow<List<MovieEntity>>
 
-    @Query("SELECT * FROM movie WHERE name LIKE '%' || :searchQuery || '%' ORDER BY name ASC")
+    @Query("SELECT * FROM movie WHERE is_live = 1 AND name LIKE '%' || :searchQuery || '%' ORDER BY name ASC")
     fun searchMovies(searchQuery: String): Flow<List<MovieEntity>>
 
-    @Query("SELECT * FROM movie WHERE year = :year ORDER BY name ASC")
+    @Query("SELECT * FROM movie WHERE is_live = 1 AND year = :year ORDER BY name ASC")
     fun getMoviesByYear(year: Int): Flow<List<MovieEntity>>
 
-    @Query("SELECT * FROM movie ORDER BY added DESC LIMIT :limit")
+    @Query("SELECT * FROM movie WHERE is_live = 1 ORDER BY added DESC LIMIT :limit")
     fun getRecentlyAddedMovies(limit: Int): Flow<List<MovieEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -70,6 +70,59 @@ interface MovieDao {
 
     @Query("SELECT COUNT(*) FROM movie")
     suspend fun getMovieCount(): Int
+
+    // --- DML versioning helpers ---
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMoviesStaging(movies: List<MovieEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertMovieCategoriesStaging(categories: List<MovieCategoryEntity>)
+
+    @Query(
+        "INSERT INTO movie(movie_id, num, name, title, year, stream_type, stream_icon, rating, rating_5based, added, container_extension, custom_sid, direct_source, is_live) " +
+            "SELECT movie_id, num, name, title, year, stream_type, stream_icon, rating, rating_5based, added, container_extension, custom_sid, direct_source, 0 FROM movie " +
+            "WHERE is_live = 1 AND (:categoryId IS NULL OR movie_id IN (SELECT movie_id FROM movie_category WHERE category_id = :categoryId AND category_type = 'movie' AND is_live = 1))"
+    )
+    suspend fun copyFromLive(categoryId: Int?)
+
+    @Query(
+        "INSERT INTO movie_category(movie_id, category_type, category_id, is_live) " +
+            "SELECT movie_id, category_type, category_id, 0 FROM movie_category " +
+            "WHERE is_live = 1 AND (:categoryId IS NULL OR category_id = :categoryId)"
+    )
+    suspend fun copyCategoriesFromLive(categoryId: Int?)
+
+    @Query("DELETE FROM movie WHERE is_live = 0")
+    suspend fun deleteStagingMovies()
+
+    @Query("DELETE FROM movie_category WHERE is_live = 0")
+    suspend fun deleteStagingCategories()
+
+    @Query("DELETE FROM movie WHERE is_live = 1")
+    suspend fun deleteLiveMovies()
+
+    @Query("DELETE FROM movie_category WHERE is_live = 1")
+    suspend fun deleteLiveMovieCategories()
+
+    @Query("UPDATE movie SET is_live = 1 WHERE is_live = 0")
+    suspend fun promoteStagingMovies()
+
+    @Query("UPDATE movie_category SET is_live = 1 WHERE is_live = 0")
+    suspend fun promoteStagingCategories()
+
+    @Transaction
+    suspend fun deleteStaging() {
+        deleteStagingMovies()
+        deleteStagingCategories()
+    }
+
+    @Transaction
+    suspend fun swapStagingToLive() {
+        deleteLiveMovies()
+        deleteLiveMovieCategories()
+        promoteStagingMovies()
+        promoteStagingCategories()
+    }
 
     @Transaction
     suspend fun insertMovieWithCategories(movie: MovieEntity, categories: List<MovieCategoryEntity>) {

--- a/app/src/main/java/com/supernova/data/dao/MovieDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/MovieDao.kt
@@ -92,6 +92,18 @@ interface MovieDao {
     )
     suspend fun copyCategoriesFromLive(categoryId: Int?)
 
+    @Query("DELETE FROM movie WHERE is_live = 0 AND movie_id IN (SELECT movie_id FROM movie_category WHERE category_id = :categoryId AND is_live = 0)")
+    suspend fun deleteStagingMoviesByCategory(categoryId: Int)
+
+    @Query("DELETE FROM movie_category WHERE category_id = :categoryId AND is_live = 0")
+    suspend fun deleteStagingCategoriesByCategory(categoryId: Int)
+
+    @Transaction
+    suspend fun deleteStagingByCategory(categoryId: Int) {
+        deleteStagingMoviesByCategory(categoryId)
+        deleteStagingCategoriesByCategory(categoryId)
+    }
+
     @Query("DELETE FROM movie WHERE is_live = 0")
     suspend fun deleteStagingMovies()
 

--- a/app/src/main/java/com/supernova/data/dao/SeriesDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/SeriesDao.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface SeriesDao {
 
-    @Query("SELECT * FROM series ORDER BY name ASC")
+    @Query("SELECT * FROM series WHERE is_live = 1 ORDER BY name ASC")
     fun getAllSeries(): Flow<List<SeriesEntity>>
 
     @Query("SELECT * FROM series WHERE series_id = :seriesId")
@@ -18,24 +18,24 @@ interface SeriesDao {
     @Query("""
         SELECT s.* FROM series s
         INNER JOIN series_category sc ON s.series_id = sc.series_id
-        WHERE sc.category_type = :categoryType AND sc.category_id = :categoryId
+        WHERE sc.category_type = :categoryType AND sc.category_id = :categoryId AND s.is_live = 1 AND sc.is_live = 1
         ORDER BY s.name ASC
     """)
     fun getSeriesByCategory(categoryType: String, categoryId: Int): Flow<List<SeriesEntity>>
 
-    @Query("SELECT * FROM series WHERE name LIKE '%' || :searchQuery || '%' OR title LIKE '%' || :searchQuery || '%' ORDER BY name ASC")
+    @Query("SELECT * FROM series WHERE is_live = 1 AND (name LIKE '%' || :searchQuery || '%' OR title LIKE '%' || :searchQuery || '%') ORDER BY name ASC")
     fun searchSeries(searchQuery: String): Flow<List<SeriesEntity>>
 
-    @Query("SELECT * FROM series WHERE year = :year ORDER BY name ASC")
+    @Query("SELECT * FROM series WHERE is_live = 1 AND year = :year ORDER BY name ASC")
     fun getSeriesByYear(year: String): Flow<List<SeriesEntity>>
 
-    @Query("SELECT * FROM series WHERE genre LIKE '%' || :genre || '%' ORDER BY name ASC")
+    @Query("SELECT * FROM series WHERE is_live = 1 AND genre LIKE '%' || :genre || '%' ORDER BY name ASC")
     fun getSeriesByGenre(genre: String): Flow<List<SeriesEntity>>
 
-    @Query("SELECT * FROM series ORDER BY last_modified DESC LIMIT :limit")
+    @Query("SELECT * FROM series WHERE is_live = 1 ORDER BY last_modified DESC LIMIT :limit")
     fun getRecentlyUpdatedSeries(limit: Int): Flow<List<SeriesEntity>>
 
-    @Query("SELECT * FROM series WHERE rating_5based >= :minRating ORDER BY rating_5based DESC")
+    @Query("SELECT * FROM series WHERE is_live = 1 AND rating_5based >= :minRating ORDER BY rating_5based DESC")
     fun getTopRatedSeries(minRating: Float): Flow<List<SeriesEntity>>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
@@ -61,6 +61,59 @@ interface SeriesDao {
 
     @Query("SELECT COUNT(*) FROM series WHERE series_id IN (SELECT series_id FROM series_category WHERE category_type = :categoryType AND category_id = :categoryId)")
     suspend fun getSeriesCountByCategory(categoryType: String, categoryId: Int): Int
+
+    // --- DML versioning helpers ---
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSeriesStaging(seriesList: List<SeriesEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertSeriesCategoriesStaging(categories: List<SeriesCategoryEntity>)
+
+    @Query(
+        "INSERT INTO series(series_id, num, name, title, year, stream_type, cover, plot, cast, director, genre, release_date, releaseDate, last_modified, rating, rating_5based, backdrop_path, youtube_trailer, episode_run_time, is_live) " +
+            "SELECT series_id, num, name, title, year, stream_type, cover, plot, cast, director, genre, release_date, releaseDate, last_modified, rating, rating_5based, backdrop_path, youtube_trailer, episode_run_time, 0 FROM series " +
+            "WHERE is_live = 1 AND (:categoryId IS NULL OR series_id IN (SELECT series_id FROM series_category WHERE category_id = :categoryId AND category_type = 'series' AND is_live = 1))"
+    )
+    suspend fun copyFromLive(categoryId: Int?)
+
+    @Query(
+        "INSERT INTO series_category(series_id, category_type, category_id, is_live) " +
+            "SELECT series_id, category_type, category_id, 0 FROM series_category " +
+            "WHERE is_live = 1 AND (:categoryId IS NULL OR category_id = :categoryId)"
+    )
+    suspend fun copyCategoriesFromLive(categoryId: Int?)
+
+    @Query("DELETE FROM series WHERE is_live = 0")
+    suspend fun deleteStagingSeries()
+
+    @Query("DELETE FROM series_category WHERE is_live = 0")
+    suspend fun deleteStagingCategories()
+
+    @Query("DELETE FROM series WHERE is_live = 1")
+    suspend fun deleteLiveSeries()
+
+    @Query("DELETE FROM series_category WHERE is_live = 1")
+    suspend fun deleteLiveSeriesCategories()
+
+    @Query("UPDATE series SET is_live = 1 WHERE is_live = 0")
+    suspend fun promoteStagingSeries()
+
+    @Query("UPDATE series_category SET is_live = 1 WHERE is_live = 0")
+    suspend fun promoteStagingCategories()
+
+    @Transaction
+    suspend fun deleteStaging() {
+        deleteStagingSeries()
+        deleteStagingCategories()
+    }
+
+    @Transaction
+    suspend fun swapStagingToLive() {
+        deleteLiveSeries()
+        deleteLiveSeriesCategories()
+        promoteStagingSeries()
+        promoteStagingCategories()
+    }
 
     // Series-Category relationship operations
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/app/src/main/java/com/supernova/data/dao/SeriesDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/SeriesDao.kt
@@ -83,6 +83,18 @@ interface SeriesDao {
     )
     suspend fun copyCategoriesFromLive(categoryId: Int?)
 
+    @Query("DELETE FROM series WHERE is_live = 0 AND series_id IN (SELECT series_id FROM series_category WHERE category_id = :categoryId AND is_live = 0)")
+    suspend fun deleteStagingSeriesByCategory(categoryId: Int)
+
+    @Query("DELETE FROM series_category WHERE category_id = :categoryId AND is_live = 0")
+    suspend fun deleteStagingCategoriesByCategory(categoryId: Int)
+
+    @Transaction
+    suspend fun deleteStagingByCategory(categoryId: Int) {
+        deleteStagingSeriesByCategory(categoryId)
+        deleteStagingCategoriesByCategory(categoryId)
+    }
+
     @Query("DELETE FROM series WHERE is_live = 0")
     suspend fun deleteStagingSeries()
 

--- a/app/src/main/java/com/supernova/data/database/SuperNovaDatabase.kt
+++ b/app/src/main/java/com/supernova/data/database/SuperNovaDatabase.kt
@@ -36,7 +36,7 @@ import com.supernova.network.AvatarService
         ChannelEntity::class,
         EpgEntity::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 abstract class SupernovaDatabase : RoomDatabase() {
@@ -60,7 +60,7 @@ abstract class SupernovaDatabase : RoomDatabase() {
                     SupernovaDatabase::class.java,
                     "supernova"
                 )
-                    .addMigrations(MIGRATION_5_6)
+                    .addMigrations(MIGRATION_5_6, MIGRATION_6_7)
                     .build()
                 INSTANCE = instance
                 instance
@@ -77,4 +77,70 @@ abstract class SupernovaDatabase : RoomDatabase() {
                 database.execSQL("ALTER TABLE series_category ADD COLUMN is_live INTEGER NOT NULL DEFAULT 1")
             }
         }
-    }}
+
+        val MIGRATION_6_7 = object : Migration(6, 7) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("CREATE TABLE category_new (uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, type TEXT NOT NULL, id INTEGER NOT NULL, name TEXT NOT NULL, parent_id INTEGER NOT NULL, is_live INTEGER NOT NULL DEFAULT 1)")
+                database.execSQL("INSERT INTO category_new (type, id, name, parent_id, is_live) SELECT type, id, name, parent_id, is_live FROM category")
+                database.execSQL("DROP TABLE category")
+                database.execSQL("ALTER TABLE category_new RENAME TO category")
+                database.execSQL("CREATE UNIQUE INDEX index_category_type_id_is_live ON category(type,id,is_live)")
+                database.execSQL("CREATE INDEX index_category_type ON category(type)")
+                database.execSQL("CREATE INDEX index_category_is_live ON category(is_live)")
+                database.execSQL("CREATE INDEX index_category_type_is_live ON category(type,is_live)")
+
+                database.execSQL("CREATE TABLE movie_new (uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, movie_id INTEGER NOT NULL, num INTEGER, name TEXT NOT NULL, title TEXT, year INTEGER, stream_type TEXT, stream_icon TEXT, rating REAL, rating_5based REAL, added INTEGER, container_extension TEXT, custom_sid TEXT, direct_source TEXT, is_live INTEGER NOT NULL DEFAULT 1)")
+                database.execSQL("INSERT INTO movie_new (movie_id, num, name, title, year, stream_type, stream_icon, rating, rating_5based, added, container_extension, custom_sid, direct_source, is_live) SELECT movie_id, num, name, title, year, stream_type, stream_icon, rating, rating_5based, added, container_extension, custom_sid, direct_source, is_live FROM movie")
+                database.execSQL("DROP TABLE movie")
+                database.execSQL("ALTER TABLE movie_new RENAME TO movie")
+                database.execSQL("CREATE UNIQUE INDEX index_movie_movie_id_is_live ON movie(movie_id,is_live)")
+                database.execSQL("CREATE INDEX index_movie_movie_id ON movie(movie_id)")
+                database.execSQL("CREATE INDEX index_movie_is_live ON movie(is_live)")
+                database.execSQL("CREATE INDEX index_movie_name ON movie(name)")
+                database.execSQL("CREATE INDEX index_movie_year ON movie(year)")
+                database.execSQL("CREATE INDEX index_movie_added ON movie(added)")
+
+                database.execSQL("CREATE TABLE live_tv_new (uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, channel_id INTEGER NOT NULL, num INTEGER, name TEXT NOT NULL, stream_type TEXT, stream_icon TEXT, epg_channel_id TEXT, added INTEGER, custom_sid TEXT, tv_archive INTEGER, direct_source TEXT, tv_archive_duration INTEGER, category_type TEXT, category_id INTEGER, thumbnail TEXT, is_live INTEGER NOT NULL DEFAULT 1)")
+                database.execSQL("INSERT INTO live_tv_new (channel_id, num, name, stream_type, stream_icon, epg_channel_id, added, custom_sid, tv_archive, direct_source, tv_archive_duration, category_type, category_id, thumbnail, is_live) SELECT channel_id, num, name, stream_type, stream_icon, epg_channel_id, added, custom_sid, tv_archive, direct_source, tv_archive_duration, category_type, category_id, thumbnail, is_live FROM live_tv")
+                database.execSQL("DROP TABLE live_tv")
+                database.execSQL("ALTER TABLE live_tv_new RENAME TO live_tv")
+                database.execSQL("CREATE UNIQUE INDEX index_live_tv_channel_id_is_live ON live_tv(channel_id,is_live)")
+                database.execSQL("CREATE INDEX index_live_tv_channel_id ON live_tv(channel_id)")
+                database.execSQL("CREATE INDEX index_live_tv_is_live ON live_tv(is_live)")
+                database.execSQL("CREATE INDEX index_live_tv_name ON live_tv(name)")
+                database.execSQL("CREATE INDEX index_live_tv_category_id ON live_tv(category_id)")
+                database.execSQL("CREATE INDEX index_live_tv_category_type_category_id ON live_tv(category_type,category_id)")
+
+                database.execSQL("CREATE TABLE series_new (uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, series_id INTEGER NOT NULL, num INTEGER, name TEXT NOT NULL, title TEXT, year TEXT, stream_type TEXT, cover TEXT, plot TEXT, cast TEXT, director TEXT, genre TEXT, release_date TEXT, releaseDate TEXT, last_modified TEXT, rating TEXT, rating_5based REAL, backdrop_path TEXT, youtube_trailer TEXT, episode_run_time TEXT, is_live INTEGER NOT NULL DEFAULT 1)")
+                database.execSQL("INSERT INTO series_new (series_id, num, name, title, year, stream_type, cover, plot, cast, director, genre, release_date, releaseDate, last_modified, rating, rating_5based, backdrop_path, youtube_trailer, episode_run_time, is_live) SELECT series_id, num, name, title, year, stream_type, cover, plot, cast, director, genre, release_date, releaseDate, last_modified, rating, rating_5based, backdrop_path, youtube_trailer, episode_run_time, is_live FROM series")
+                database.execSQL("DROP TABLE series")
+                database.execSQL("ALTER TABLE series_new RENAME TO series")
+                database.execSQL("CREATE UNIQUE INDEX index_series_series_id_is_live ON series(series_id,is_live)")
+                database.execSQL("CREATE INDEX index_series_series_id ON series(series_id)")
+                database.execSQL("CREATE INDEX index_series_is_live ON series(is_live)")
+                database.execSQL("CREATE INDEX index_series_name ON series(name)")
+                database.execSQL("CREATE INDEX index_series_year ON series(year)")
+                database.execSQL("CREATE INDEX index_series_genre ON series(genre)")
+
+                database.execSQL("CREATE TABLE movie_category_new (uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, movie_id INTEGER NOT NULL, category_type TEXT NOT NULL, category_id INTEGER NOT NULL, is_live INTEGER NOT NULL DEFAULT 1)")
+                database.execSQL("INSERT INTO movie_category_new (movie_id, category_type, category_id, is_live) SELECT movie_id, category_type, category_id, is_live FROM movie_category")
+                database.execSQL("DROP TABLE movie_category")
+                database.execSQL("ALTER TABLE movie_category_new RENAME TO movie_category")
+                database.execSQL("CREATE UNIQUE INDEX index_movie_category_unique ON movie_category(movie_id,category_type,category_id,is_live)")
+                database.execSQL("CREATE INDEX index_movie_category_movie_id ON movie_category(movie_id)")
+                database.execSQL("CREATE INDEX index_movie_category_category_type_category_id ON movie_category(category_type,category_id)")
+                database.execSQL("CREATE INDEX index_movie_category_is_live ON movie_category(is_live)")
+                database.execSQL("CREATE INDEX index_movie_category_movie_id_is_live ON movie_category(movie_id,is_live)")
+
+                database.execSQL("CREATE TABLE series_category_new (uid INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, series_id INTEGER NOT NULL, category_type TEXT NOT NULL, category_id INTEGER NOT NULL, is_live INTEGER NOT NULL DEFAULT 1)")
+                database.execSQL("INSERT INTO series_category_new (series_id, category_type, category_id, is_live) SELECT series_id, category_type, category_id, is_live FROM series_category")
+                database.execSQL("DROP TABLE series_category")
+                database.execSQL("ALTER TABLE series_category_new RENAME TO series_category")
+                database.execSQL("CREATE UNIQUE INDEX index_series_category_unique ON series_category(series_id,category_type,category_id,is_live)")
+                database.execSQL("CREATE INDEX index_series_category_series_id ON series_category(series_id)")
+                database.execSQL("CREATE INDEX index_series_category_category_type_category_id ON series_category(category_type,category_id)")
+                database.execSQL("CREATE INDEX index_series_category_is_live ON series_category(is_live)")
+                database.execSQL("CREATE INDEX index_series_category_series_id_is_live ON series_category(series_id,is_live)")
+            }
+        }
+    }

--- a/app/src/main/java/com/supernova/data/database/SuperNovaDatabase.kt
+++ b/app/src/main/java/com/supernova/data/database/SuperNovaDatabase.kt
@@ -36,7 +36,7 @@ import com.supernova.network.AvatarService
         ChannelEntity::class,
         EpgEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 abstract class SupernovaDatabase : RoomDatabase() {
@@ -60,9 +60,21 @@ abstract class SupernovaDatabase : RoomDatabase() {
                     SupernovaDatabase::class.java,
                     "supernova"
                 )
+                    .addMigrations(MIGRATION_5_6)
                     .build()
                 INSTANCE = instance
                 instance
+            }
+        }
+
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE category ADD COLUMN is_live INTEGER NOT NULL DEFAULT 1")
+                database.execSQL("ALTER TABLE movie ADD COLUMN is_live INTEGER NOT NULL DEFAULT 1")
+                database.execSQL("ALTER TABLE live_tv ADD COLUMN is_live INTEGER NOT NULL DEFAULT 1")
+                database.execSQL("ALTER TABLE series ADD COLUMN is_live INTEGER NOT NULL DEFAULT 1")
+                database.execSQL("ALTER TABLE movie_category ADD COLUMN is_live INTEGER NOT NULL DEFAULT 1")
+                database.execSQL("ALTER TABLE series_category ADD COLUMN is_live INTEGER NOT NULL DEFAULT 1")
             }
         }
     }}

--- a/app/src/main/java/com/supernova/data/entities/CategoryEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/CategoryEntity.kt
@@ -6,14 +6,15 @@ import androidx.room.PrimaryKey
 
 @Entity(
     tableName = "category",
-    primaryKeys = ["type", "id"],
     indices = [
         Index("type"),
         Index("is_live"),
-        Index(value = ["type", "is_live"])
+        Index(value = ["type", "is_live"]),
+        Index(value = ["type", "id", "is_live"], unique = true)
     ]
 )
 data class CategoryEntity(
+    @PrimaryKey(autoGenerate = true) val uid: Long = 0,
     val type: String,           // e.g., 'movie', 'live_tv'
     val id: Int,                // category id within type
     val name: String,

--- a/app/src/main/java/com/supernova/data/entities/CategoryEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/CategoryEntity.kt
@@ -1,16 +1,22 @@
 package com.supernova.data.entities
 
 import androidx.room.Entity
-import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 @Entity(
     tableName = "category",
-    primaryKeys = ["type", "id"]
+    primaryKeys = ["type", "id"],
+    indices = [
+        Index("type"),
+        Index("is_live"),
+        Index(value = ["type", "is_live"])
+    ]
 )
 data class CategoryEntity(
     val type: String,           // e.g., 'movie', 'live_tv'
     val id: Int,                // category id within type
     val name: String,
-    val parent_id: Int = 0
+    val parent_id: Int = 0,
+    val is_live: Boolean = true
 )

--- a/app/src/main/java/com/supernova/data/entities/LiveTvEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/LiveTvEntity.kt
@@ -1,18 +1,17 @@
 package com.supernova.data.entities
 
 import androidx.room.Entity
-import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
 @Entity(
     tableName = "live_tv",
-    foreignKeys = [
-        ForeignKey(
-            entity = CategoryEntity::class,
-            parentColumns = ["type", "id"],
-            childColumns = ["category_type", "category_id"],
-            onDelete = ForeignKey.SET_NULL
-        )
+    indices = [
+        Index("channel_id"),
+        Index("is_live"),
+        Index("name"),
+        Index("category_id"),
+        Index(value = ["category_type", "category_id"])
     ]
 )
 data class LiveTvEntity(
@@ -30,5 +29,6 @@ data class LiveTvEntity(
     val tv_archive_duration: Int?,
     val category_type: String?,
     val category_id: Int?,
-    val thumbnail: String?
+    val thumbnail: String?,
+    val is_live: Boolean = true
 )

--- a/app/src/main/java/com/supernova/data/entities/LiveTvEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/LiveTvEntity.kt
@@ -11,11 +11,12 @@ import androidx.room.PrimaryKey
         Index("is_live"),
         Index("name"),
         Index("category_id"),
-        Index(value = ["category_type", "category_id"])
+        Index(value = ["category_type", "category_id"]),
+        Index(value = ["channel_id", "is_live"], unique = true)
     ]
 )
 data class LiveTvEntity(
-    @PrimaryKey
+    @PrimaryKey(autoGenerate = true) val uid: Long = 0,
     val channel_id: Int,            // Corresponds to stream_id
     val num: Int?,
     val name: String,

--- a/app/src/main/java/com/supernova/data/entities/MovieCategoryEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/MovieCategoryEntity.kt
@@ -5,15 +5,16 @@ import androidx.room.Index
 
 @Entity(
     tableName = "movie_category",
-    primaryKeys = ["movie_id", "category_type", "category_id"],
     indices = [
         Index("movie_id"),
         Index(value = ["category_type", "category_id"]),
         Index("is_live"),
-        Index(value = ["movie_id", "is_live"])
+        Index(value = ["movie_id", "is_live"]),
+        Index(value = ["movie_id", "category_type", "category_id", "is_live"], unique = true)
     ]
 )
 data class MovieCategoryEntity(
+    @PrimaryKey(autoGenerate = true) val uid: Long = 0,
     val movie_id: Int,
     val category_type: String,
     val category_id: Int,

--- a/app/src/main/java/com/supernova/data/entities/MovieCategoryEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/MovieCategoryEntity.kt
@@ -1,28 +1,21 @@
 package com.supernova.data.entities
 
 import androidx.room.Entity
-import androidx.room.ForeignKey
+import androidx.room.Index
 
 @Entity(
     tableName = "movie_category",
     primaryKeys = ["movie_id", "category_type", "category_id"],
-    foreignKeys = [
-        ForeignKey(
-            entity = MovieEntity::class,
-            parentColumns = ["movie_id"],
-            childColumns = ["movie_id"],
-            onDelete = ForeignKey.CASCADE
-        ),
-        ForeignKey(
-            entity = CategoryEntity::class,
-            parentColumns = ["type", "id"],
-            childColumns = ["category_type", "category_id"],
-            onDelete = ForeignKey.CASCADE
-        )
+    indices = [
+        Index("movie_id"),
+        Index(value = ["category_type", "category_id"]),
+        Index("is_live"),
+        Index(value = ["movie_id", "is_live"])
     ]
 )
 data class MovieCategoryEntity(
     val movie_id: Int,
     val category_type: String,
-    val category_id: Int
+    val category_id: Int,
+    val is_live: Boolean = true
 )

--- a/app/src/main/java/com/supernova/data/entities/MovieEntitiy.kt
+++ b/app/src/main/java/com/supernova/data/entities/MovieEntitiy.kt
@@ -1,9 +1,19 @@
 package com.supernova.data.entities
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "movie")
+@Entity(
+    tableName = "movie",
+    indices = [
+        Index("movie_id"),
+        Index("is_live"),
+        Index("name"),
+        Index("year"),
+        Index("added")
+    ]
+)
 data class MovieEntity(
     @PrimaryKey
     val movie_id: Int,              // Corresponds to stream_id
@@ -18,5 +28,6 @@ data class MovieEntity(
     val added: Long?,               // Unix timestamp
     val container_extension: String?,
     val custom_sid: String?,
-    val direct_source: String?
+    val direct_source: String?,
+    val is_live: Boolean = true
 )

--- a/app/src/main/java/com/supernova/data/entities/MovieEntitiy.kt
+++ b/app/src/main/java/com/supernova/data/entities/MovieEntitiy.kt
@@ -11,11 +11,12 @@ import androidx.room.PrimaryKey
         Index("is_live"),
         Index("name"),
         Index("year"),
-        Index("added")
+        Index("added"),
+        Index(value = ["movie_id", "is_live"], unique = true)
     ]
 )
 data class MovieEntity(
-    @PrimaryKey
+    @PrimaryKey(autoGenerate = true) val uid: Long = 0,
     val movie_id: Int,              // Corresponds to stream_id
     val num: Int?,
     val name: String,

--- a/app/src/main/java/com/supernova/data/entities/SeriesCategoryEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/SeriesCategoryEntity.kt
@@ -1,28 +1,21 @@
 package com.supernova.data.entities
 
 import androidx.room.Entity
-import androidx.room.ForeignKey
+import androidx.room.Index
 
 @Entity(
     tableName = "series_category",
     primaryKeys = ["series_id", "category_type", "category_id"],
-    foreignKeys = [
-        ForeignKey(
-            entity = SeriesEntity::class,
-            parentColumns = ["series_id"],
-            childColumns = ["series_id"],
-            onDelete = ForeignKey.CASCADE
-        ),
-        ForeignKey(
-            entity = CategoryEntity::class,
-            parentColumns = ["type", "id"],
-            childColumns = ["category_type", "category_id"],
-            onDelete = ForeignKey.CASCADE
-        )
+    indices = [
+        Index("series_id"),
+        Index(value = ["category_type", "category_id"]),
+        Index("is_live"),
+        Index(value = ["series_id", "is_live"])
     ]
 )
 data class SeriesCategoryEntity(
     val series_id: Int,
     val category_type: String,
-    val category_id: Int
+    val category_id: Int,
+    val is_live: Boolean = true
 )

--- a/app/src/main/java/com/supernova/data/entities/SeriesCategoryEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/SeriesCategoryEntity.kt
@@ -5,15 +5,16 @@ import androidx.room.Index
 
 @Entity(
     tableName = "series_category",
-    primaryKeys = ["series_id", "category_type", "category_id"],
     indices = [
         Index("series_id"),
         Index(value = ["category_type", "category_id"]),
         Index("is_live"),
-        Index(value = ["series_id", "is_live"])
+        Index(value = ["series_id", "is_live"]),
+        Index(value = ["series_id", "category_type", "category_id", "is_live"], unique = true)
     ]
 )
 data class SeriesCategoryEntity(
+    @PrimaryKey(autoGenerate = true) val uid: Long = 0,
     val series_id: Int,
     val category_type: String,
     val category_id: Int,

--- a/app/src/main/java/com/supernova/data/entities/SeriesEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/SeriesEntity.kt
@@ -11,11 +11,12 @@ import androidx.room.PrimaryKey
         Index("is_live"),
         Index("name"),
         Index("year"),
-        Index("genre")
+        Index("genre"),
+        Index(value = ["series_id", "is_live"], unique = true)
     ]
 )
 data class SeriesEntity(
-    @PrimaryKey
+    @PrimaryKey(autoGenerate = true) val uid: Long = 0,
     val series_id: Int,
     val num: Int?,
     val name: String,

--- a/app/src/main/java/com/supernova/data/entities/SeriesEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/SeriesEntity.kt
@@ -1,9 +1,19 @@
 package com.supernova.data.entities
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "series")
+@Entity(
+    tableName = "series",
+    indices = [
+        Index("series_id"),
+        Index("is_live"),
+        Index("name"),
+        Index("year"),
+        Index("genre")
+    ]
+)
 data class SeriesEntity(
     @PrimaryKey
     val series_id: Int,
@@ -24,5 +34,6 @@ data class SeriesEntity(
     val rating_5based: Float?,
     val backdrop_path: String?,        // JSON array as string
     val youtube_trailer: String?,
-    val episode_run_time: String?
+    val episode_run_time: String?,
+    val is_live: Boolean = true
 )

--- a/app/src/main/java/com/supernova/network/ApiService.kt
+++ b/app/src/main/java/com/supernova/network/ApiService.kt
@@ -75,6 +75,36 @@ interface ApiService {
         @Query("action") action: String = "get_series"
     ): Response<ResponseBody>
 
+    @Streaming
+    @GET
+    suspend fun getLiveStreamsByCategory(
+        @Url url: String,
+        @Query("username") username: String,
+        @Query("password") password: String,
+        @Query("category_id") categoryId: Int,
+        @Query("action") action: String = "get_live_streams"
+    ): Response<ResponseBody>
+
+    @Streaming
+    @GET
+    suspend fun getVodStreamsByCategory(
+        @Url url: String,
+        @Query("username") username: String,
+        @Query("password") password: String,
+        @Query("category_id") categoryId: Int,
+        @Query("action") action: String = "get_vod_streams"
+    ): Response<ResponseBody>
+
+    @Streaming
+    @GET
+    suspend fun getSeriesStreamsByCategory(
+        @Url url: String,
+        @Query("username") username: String,
+        @Query("password") password: String,
+        @Query("category_id") categoryId: Int,
+        @Query("action") action: String = "get_series"
+    ): Response<ResponseBody>
+
     @GET
     suspend fun downloadEpg(
         @Url url: String,

--- a/app/src/main/java/com/supernova/network/DataSyncService.kt
+++ b/app/src/main/java/com/supernova/network/DataSyncService.kt
@@ -16,6 +16,9 @@ import com.supernova.utils.SecureDataStore
 import com.supernova.utils.SecureStorageKeys
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.supervisorScope
 
 class DataSyncService(
     private val database: SupernovaDatabase,
@@ -31,88 +34,34 @@ class DataSyncService(
     // In DataSyncService.kt
 
 
-    suspend fun syncTV(
+    suspend fun syncTVWithVersioning(
         apiService: ApiService,
         baseUrl: String,
         username: String,
         password: String
     ) {
-        val catResp = apiService.getLiveCategories(baseUrl, username, password)
-        if (!catResp.isSuccessful) throw Exception("Live category API ${catResp.code()}")
-        val categories = mapCategories(catResp.body() ?: emptyList(), "live_tv")
-
-        val response = apiService.getLiveStreams(baseUrl, username, password)
-        if (!response.isSuccessful) throw Exception("Live stream API ${response.code()}")
-        val responseBody = response.body()!!
-
-        database.withTransaction {
-            database.categoryDao().deleteCategoriesByType("live_tv")
-            database.categoryDao().insertCategories(categories)
-            database.categoryDao()
-                .insertCategory(CategoryEntity("live_tv", UNCATEGORIZED_ID, UNCATEGORIZED_NAME))
-            database.liveTvDao().deleteAllChannels()
-            // Streaming: map and insert each batch
-            ApiUtils.batchJsonStream<LiveTvResponse>(this, responseBody) { batch ->
-                val entities = mapLiveStreams(batch)
-                database.liveTvDao().insertChannels(entities) // Insert this batch
-            }
-        }
+        val categories = downloadCategoriesForType(apiService, baseUrl, username, password, "get_live_categories", "live_tv")
+        processContentTypeWithWorkers(apiService, baseUrl, username, password, "live_tv", categories)
     }
 
-    suspend fun syncSeries(
+    suspend fun syncSeriesWithVersioning(
         apiService: ApiService,
         baseUrl: String,
         username: String,
         password: String
     ) {
-        val catResp = apiService.getSeriesCategories(baseUrl, username, password)
-        if (!catResp.isSuccessful) throw Exception("Series category API ${catResp.code()}")
-        val categories = mapCategories(catResp.body() ?: emptyList(), "series")
-
-        val streamResp = apiService.getSeriesStreams(baseUrl, username, password)
-        if (!streamResp.isSuccessful) throw Exception("Series stream API ${streamResp.code()}")
-        val responseBody = streamResp.body()!!
-
-        database.withTransaction {
-            database.categoryDao().deleteCategoriesByType("series")
-            database.categoryDao().insertCategories(categories)
-            database.categoryDao()
-                .insertCategory(CategoryEntity("series", UNCATEGORIZED_ID, UNCATEGORIZED_NAME))
-            database.seriesDao().deleteAllSeries()
-            ApiUtils.batchJsonStream<SeriesResponse>(this, responseBody) { batch ->
-                val (series, seriesCats) = mapSeriesStreams(batch)
-                database.seriesDao().insertSeriesList(series)
-                if (seriesCats.isNotEmpty()) database.seriesDao().insertSeriesCategories(seriesCats)
-            }
-        }
+        val categories = downloadCategoriesForType(apiService, baseUrl, username, password, "get_series_categories", "series")
+        processContentTypeWithWorkers(apiService, baseUrl, username, password, "series", categories)
     }
 
-    suspend fun syncMovies(
+    suspend fun syncMoviesWithVersioning(
         apiService: ApiService,
         baseUrl: String,
         username: String,
         password: String
     ) {
-        val catResp = apiService.getVodCategories(baseUrl, username, password)
-        if (!catResp.isSuccessful) throw Exception("VOD category API ${catResp.code()}")
-        val categories = mapCategories(catResp.body() ?: emptyList(), "movie")
-
-        val streamResp = apiService.getVodStreams(baseUrl, username, password)
-        if (!streamResp.isSuccessful) throw Exception("VOD stream API ${streamResp.code()}")
-        val responseBody = streamResp.body()!!
-
-        database.withTransaction {
-            database.categoryDao().deleteCategoriesByType("movie")
-            database.categoryDao().insertCategories(categories)
-            database.categoryDao()
-                .insertCategory(CategoryEntity("movie", UNCATEGORIZED_ID, UNCATEGORIZED_NAME))
-            database.movieDao().deleteAllMovies()
-            ApiUtils.batchJsonStream<SeriesResponse>(this, responseBody) { batch ->
-                val (movies, moviesCats) = mapSeriesStreams(batch)
-                database.seriesDao().insertSeriesList(movies)
-                if (moviesCats.isNotEmpty()) database.seriesDao().insertSeriesCategories(moviesCats)
-            }
-        }
+        val categories = downloadCategoriesForType(apiService, baseUrl, username, password, "get_vod_categories", "movie")
+        processContentTypeWithWorkers(apiService, baseUrl, username, password, "movie", categories)
     }
 
     suspend fun syncEPG(
@@ -138,6 +87,8 @@ class DataSyncService(
 
     fun syncAll(): Flow<SyncResult> = flow {
         Log.d(TAG, "Starting sync process")
+
+        startupCleanup()
 
         val portal = SecureDataStore.getString(SecureStorageKeys.PORTAL)
         val username = SecureDataStore.getString(SecureStorageKeys.USERNAME)
@@ -166,7 +117,7 @@ class DataSyncService(
 
             emit(SyncResult.Progress("Syncing live TV...", 1, 7))
             try {
-                syncTV(apiService, baseUrl, username, password)
+                syncTVWithVersioning(apiService, baseUrl, username, password)
             } catch (e: Exception) {
                 emit(SyncResult.Error("Live TV sync failed: ${e.message}"))
                 return@flow
@@ -174,7 +125,7 @@ class DataSyncService(
 
             emit(SyncResult.Progress("Syncing movies...", 2, 7))
             try {
-                syncMovies(apiService, baseUrl, username, password)
+                syncMoviesWithVersioning(apiService, baseUrl, username, password)
             } catch (e: Exception) {
                 emit(SyncResult.Error("VOD sync failed: ${e.message}"))
                 return@flow
@@ -182,7 +133,7 @@ class DataSyncService(
 
             emit(SyncResult.Progress("Syncing series...", 3, 7))
             try {
-                syncSeries(apiService, baseUrl, username, password)
+                syncSeriesWithVersioning(apiService, baseUrl, username, password)
             } catch (e: Exception) {
                 emit(SyncResult.Error("Series sync failed: ${e.message}"))
                 return@flow
@@ -196,11 +147,14 @@ class DataSyncService(
                 return@flow
             }
 
+            swapVersioningToLive()
             emit(SyncResult.Success)
 
         } catch (e: Exception) {
             Log.e(TAG, "Sync failed with exception", e)
             emit(SyncResult.Error("Sync failed: ${e.message}"))
+        } finally {
+            deleteAllStaging()
         }
     }
 
@@ -462,6 +416,126 @@ class DataSyncService(
             "Parsed ${seriesEntities.size} series and ${seriesCategoryEntities.size} series-category relations"
         )
         return seriesEntities to seriesCategoryEntities
+    }
+
+    private suspend fun startupCleanup() {
+        database.categoryDao().deleteStaging()
+        database.movieDao().deleteStaging()
+        database.liveTvDao().deleteStaging()
+        database.seriesDao().deleteStaging()
+    }
+
+    private suspend fun downloadCategoriesForType(
+        apiService: ApiService,
+        baseUrl: String,
+        username: String,
+        password: String,
+        action: String,
+        type: String
+    ): List<CategoryEntity> {
+        val resp = when (action) {
+            "get_live_categories" -> apiService.getLiveCategories(baseUrl, username, password, action)
+            "get_vod_categories" -> apiService.getVodCategories(baseUrl, username, password, action)
+            "get_series_categories" -> apiService.getSeriesCategories(baseUrl, username, password, action)
+            else -> apiService.getLiveCategories(baseUrl, username, password, action)
+        }
+        if (!resp.isSuccessful) throw Exception("Category API ${resp.code()}")
+        val cats = mapCategories(resp.body() ?: emptyList(), type)
+        database.categoryDao().insertCategoriesStaging(cats)
+        return cats
+    }
+
+    private suspend fun downloadStreamsForCategory(
+        apiService: ApiService,
+        baseUrl: String,
+        username: String,
+        password: String,
+        category: CategoryEntity
+    ) {
+        when (category.type) {
+            "live_tv" -> {
+                val resp = apiService.getLiveStreamsByCategory(baseUrl, username, password, category.id)
+                if (resp.isSuccessful) {
+                    ApiUtils.batchJsonStream<LiveTvResponse>(this, resp.body()!!) { batch ->
+                        val entities = mapLiveStreams(batch)
+                        database.liveTvDao().insertChannelsStaging(entities)
+                    }
+                } else throw Exception("Live streams API ${resp.code()}")
+            }
+            "movie" -> {
+                val resp = apiService.getVodStreamsByCategory(baseUrl, username, password, category.id)
+                if (resp.isSuccessful) {
+                    ApiUtils.batchJsonStream<VodResponse>(this, resp.body()!!) { batch ->
+                        val (movies, cats) = mapVodStreams(batch)
+                        database.movieDao().insertMoviesStaging(movies)
+                        database.movieDao().insertMovieCategoriesStaging(cats)
+                    }
+                } else throw Exception("VOD streams API ${resp.code()}")
+            }
+            "series" -> {
+                val resp = apiService.getSeriesStreamsByCategory(baseUrl, username, password, category.id)
+                if (resp.isSuccessful) {
+                    ApiUtils.batchJsonStream<SeriesResponse>(this, resp.body()!!) { batch ->
+                        val (series, cats) = mapSeriesStreams(batch)
+                        database.seriesDao().insertSeriesStaging(series)
+                        database.seriesDao().insertSeriesCategoriesStaging(cats)
+                    }
+                } else throw Exception("Series streams API ${resp.code()}")
+            }
+        }
+    }
+
+    private suspend fun processContentTypeWithWorkers(
+        apiService: ApiService,
+        baseUrl: String,
+        username: String,
+        password: String,
+        type: String,
+        categories: List<CategoryEntity>
+    ) {
+        val dispatcher = Dispatchers.IO.limitedParallelism(5)
+        supervisorScope {
+            categories.map { cat ->
+                async(dispatcher) {
+                    try {
+                        downloadStreamsForCategory(apiService, baseUrl, username, password, cat)
+                    } catch (e: Exception) {
+                        Log.e(TAG, "Category sync failed for ${cat.type} category ${cat.id}: ${e.message}")
+                        handleCategoryFailure(type, cat.id)
+                    }
+                }
+            }.awaitAll()
+        }
+    }
+
+    private suspend fun handleCategoryFailure(type: String, categoryId: Int) {
+        when (type) {
+            "live_tv" -> database.liveTvDao().copyFromLive(categoryId)
+            "movie" -> {
+                database.movieDao().copyFromLive(categoryId)
+                database.movieDao().copyCategoriesFromLive(categoryId)
+            }
+            "series" -> {
+                database.seriesDao().copyFromLive(categoryId)
+                database.seriesDao().copyCategoriesFromLive(categoryId)
+            }
+        }
+    }
+
+    private suspend fun deleteAllStaging() {
+        database.categoryDao().deleteStaging()
+        database.movieDao().deleteStaging()
+        database.liveTvDao().deleteStaging()
+        database.seriesDao().deleteStaging()
+    }
+
+    private suspend fun swapVersioningToLive() {
+        database.withTransaction {
+            database.categoryDao().swapStagingToLive()
+            database.movieDao().swapStagingToLive()
+            database.liveTvDao().swapStagingToLive()
+            database.seriesDao().swapStagingToLive()
+        }
     }
 
 

--- a/app/src/main/java/com/supernova/network/DataSyncService.kt
+++ b/app/src/main/java/com/supernova/network/DataSyncService.kt
@@ -509,16 +509,11 @@ class DataSyncService(
     }
 
     private suspend fun handleCategoryFailure(type: String, categoryId: Int) {
+        database.categoryDao().deleteStagingCategory(type, categoryId)
         when (type) {
-            "live_tv" -> database.liveTvDao().copyFromLive(categoryId)
-            "movie" -> {
-                database.movieDao().copyFromLive(categoryId)
-                database.movieDao().copyCategoriesFromLive(categoryId)
-            }
-            "series" -> {
-                database.seriesDao().copyFromLive(categoryId)
-                database.seriesDao().copyCategoriesFromLive(categoryId)
-            }
+            "live_tv" -> database.liveTvDao().deleteStagingByCategory(categoryId)
+            "movie" -> database.movieDao().deleteStagingByCategory(categoryId)
+            "series" -> database.seriesDao().deleteStagingByCategory(categoryId)
         }
     }
 


### PR DESCRIPTION
## Summary
- add `is_live` column and indexes across media tables
- upgrade `SupernovaDatabase` with migration to add new versioned columns
- extend DAOs with staging helpers for DML-only versioning
- provide category-filtered API endpoints
- rewrite `DataSyncService` for per-category parallel downloads

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687249625900833399c5fb85825607ee