### PR TITLE
Add TMDB metadata support

### DIFF
--- a/app/src/main/java/com/supernova/data/dao/ContentDetailDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/ContentDetailDao.kt
@@ -1,0 +1,17 @@
+package com.supernova.data.dao
+
+import androidx.room.*
+import com.supernova.data.entities.ContentDetailEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ContentDetailDao {
+    @Query("SELECT * FROM content_detail WHERE tmdb_id = :id")
+    suspend fun getDetail(id: Int): ContentDetailEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertDetail(detail: ContentDetailEntity)
+
+    @Query("SELECT * FROM content_detail WHERE media_type = :mediaType AND genres LIKE '%' || :genre || '%'")
+    fun recommendationsByGenre(mediaType: String, genre: String): Flow<List<ContentDetailEntity>>
+}

--- a/app/src/main/java/com/supernova/data/dao/MovieDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/MovieDao.kt
@@ -4,6 +4,7 @@ import androidx.room.*
 import com.supernova.data.entities.MovieEntity
 import com.supernova.data.entities.MovieCategoryEntity
 import com.supernova.data.entities.CategoryEntity
+import com.supernova.data.entities.MovieWithDetails
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -70,6 +71,13 @@ interface MovieDao {
 
     @Query("SELECT COUNT(*) FROM movie")
     suspend fun getMovieCount(): Int
+
+    @Transaction
+    @Query("SELECT * FROM movie WHERE movie_id = :movieId")
+    suspend fun getMovieWithDetails(movieId: Int): MovieWithDetails?
+
+    @Query("SELECT * FROM movie WHERE genres LIKE '%' || :genre || '%' ORDER BY name ASC")
+    fun searchByGenre(genre: String): Flow<List<MovieEntity>>
 
     @Transaction
     suspend fun insertMovieWithCategories(movie: MovieEntity, categories: List<MovieCategoryEntity>) {

--- a/app/src/main/java/com/supernova/data/dao/SeriesDao.kt
+++ b/app/src/main/java/com/supernova/data/dao/SeriesDao.kt
@@ -4,6 +4,7 @@ import androidx.room.*
 import com.supernova.data.entities.SeriesEntity
 import com.supernova.data.entities.SeriesCategoryEntity
 import com.supernova.data.entities.CategoryEntity
+import com.supernova.data.entities.SeriesWithDetails
 import kotlinx.coroutines.flow.Flow
 
 @Dao
@@ -58,6 +59,13 @@ interface SeriesDao {
 
     @Query("SELECT COUNT(*) FROM series")
     suspend fun getSeriesCount(): Int
+
+    @Transaction
+    @Query("SELECT * FROM series WHERE series_id = :seriesId")
+    suspend fun getSeriesWithDetails(seriesId: Int): SeriesWithDetails?
+
+    @Query("SELECT * FROM series WHERE genres LIKE '%' || :genre || '%' ORDER BY name ASC")
+    fun getByGenre(genre: String): Flow<List<SeriesEntity>>
 
     @Query("SELECT COUNT(*) FROM series WHERE series_id IN (SELECT series_id FROM series_category WHERE category_type = :categoryType AND category_id = :categoryId)")
     suspend fun getSeriesCountByCategory(categoryType: String, categoryId: Int): Int

--- a/app/src/main/java/com/supernova/data/database/Migrations.kt
+++ b/app/src/main/java/com/supernova/data/database/Migrations.kt
@@ -1,0 +1,27 @@
+package com.supernova.data.database
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+val MIGRATION_7_8 = object : Migration(7, 8) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE movie ADD COLUMN backdrop_path TEXT")
+        db.execSQL("ALTER TABLE movie ADD COLUMN poster_path TEXT")
+        db.execSQL("ALTER TABLE movie ADD COLUMN overview TEXT")
+        db.execSQL("ALTER TABLE movie ADD COLUMN genres TEXT")
+        db.execSQL("ALTER TABLE movie ADD COLUMN runtime INTEGER")
+        db.execSQL("ALTER TABLE movie ADD COLUMN spoken_languages TEXT")
+
+        db.execSQL("ALTER TABLE series ADD COLUMN poster_path TEXT")
+        db.execSQL("ALTER TABLE series ADD COLUMN overview TEXT")
+        db.execSQL("ALTER TABLE series ADD COLUMN genres TEXT")
+        db.execSQL("ALTER TABLE series ADD COLUMN first_air_date TEXT")
+        db.execSQL("ALTER TABLE series ADD COLUMN last_air_date TEXT")
+        db.execSQL("ALTER TABLE series ADD COLUMN number_of_seasons INTEGER")
+        db.execSQL("ALTER TABLE series ADD COLUMN number_of_episodes INTEGER")
+
+        db.execSQL("CREATE TABLE IF NOT EXISTS content_detail (tmdb_id INTEGER PRIMARY KEY NOT NULL, media_type TEXT NOT NULL, tagline TEXT, status TEXT, homepage TEXT, genres TEXT)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_content_detail_media_type ON content_detail(media_type)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_content_detail_tmdb_id ON content_detail(tmdb_id)")
+    }
+}

--- a/app/src/main/java/com/supernova/data/database/SuperNovaDatabase.kt
+++ b/app/src/main/java/com/supernova/data/database/SuperNovaDatabase.kt
@@ -13,6 +13,8 @@ import com.supernova.data.dao.ProfileDao
 import com.supernova.data.dao.ProviderConfigDao
 import com.supernova.data.dao.SeriesDao
 import com.supernova.data.dao.WatchHistoryDao
+import com.supernova.data.dao.ContentDetailDao
+import com.supernova.data.database.MIGRATION_7_8
 import com.supernova.data.entities.CategoryEntity
 import com.supernova.data.entities.ChannelEntity
 import com.supernova.data.entities.EpgEntity
@@ -21,6 +23,7 @@ import com.supernova.data.entities.EpgProgrammeFts
 import com.supernova.data.entities.LiveTvEntity
 import com.supernova.data.entities.MovieCategoryEntity
 import com.supernova.data.entities.MovieEntity
+import com.supernova.data.entities.ContentDetailEntity
 import com.supernova.data.entities.ProfileEntity
 import com.supernova.data.entities.ProviderConfigEntity
 import com.supernova.data.entities.SeriesCategoryEntity
@@ -43,9 +46,10 @@ import com.supernova.data.entities.WatchHistoryEntity
         EpgProgrammeEntity::class,
         EpgProgrammeFts::class,
         ProviderConfigEntity::class,
-        UserProfileEntity::class
+        UserProfileEntity::class,
+        ContentDetailEntity::class
     ],
-    version = 7,
+    version = 8,
     exportSchema = false
 )
 abstract class SupernovaDatabase : RoomDatabase() {
@@ -59,6 +63,7 @@ abstract class SupernovaDatabase : RoomDatabase() {
     abstract fun epgDao(): EpgDao
     abstract fun providerConfigDao(): ProviderConfigDao
     abstract fun watchHistoryDao(): WatchHistoryDao
+    abstract fun contentDetailDao(): ContentDetailDao
 
     companion object {
         @Volatile
@@ -71,6 +76,7 @@ abstract class SupernovaDatabase : RoomDatabase() {
                     SupernovaDatabase::class.java,
                     "supernova"
                 )
+                    .addMigrations(MIGRATION_7_8)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/supernova/data/entities/ContentDetailEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/ContentDetailEntity.kt
@@ -1,0 +1,18 @@
+package com.supernova.data.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import androidx.room.Index
+
+@Entity(
+    tableName = "content_detail",
+    indices = [Index("media_type"), Index("tmdb_id")]
+)
+data class ContentDetailEntity(
+    @PrimaryKey val tmdb_id: Int,
+    val media_type: String,
+    val tagline: String?,
+    val status: String?,
+    val homepage: String?,
+    val genres: String?
+)

--- a/app/src/main/java/com/supernova/data/entities/MovieEntitiy.kt
+++ b/app/src/main/java/com/supernova/data/entities/MovieEntitiy.kt
@@ -18,5 +18,12 @@ data class MovieEntity(
     val added: Long?,               // Unix timestamp
     val container_extension: String?,
     val custom_sid: String?,
-    val direct_source: String?
+    val direct_source: String?,
+    // TMDB metadata
+    val backdrop_path: String?,
+    val poster_path: String?,
+    val overview: String?,
+    val genres: String?,
+    val runtime: Int?,
+    val spoken_languages: String?
 )

--- a/app/src/main/java/com/supernova/data/entities/MovieWithDetails.kt
+++ b/app/src/main/java/com/supernova/data/entities/MovieWithDetails.kt
@@ -1,0 +1,10 @@
+package com.supernova.data.entities
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class MovieWithDetails(
+    @Embedded val movie: MovieEntity,
+    @Relation(parentColumn = "movie_id", entityColumn = "tmdb_id")
+    val details: ContentDetailEntity?
+)

--- a/app/src/main/java/com/supernova/data/entities/SeriesEntity.kt
+++ b/app/src/main/java/com/supernova/data/entities/SeriesEntity.kt
@@ -24,5 +24,13 @@ data class SeriesEntity(
     val rating_5based: Float?,
     val backdrop_path: String?,        // JSON array as string
     val youtube_trailer: String?,
-    val episode_run_time: String?
+    val episode_run_time: String?,
+    // TMDB metadata
+    val poster_path: String?,
+    val overview: String?,
+    val genres: String?,
+    val first_air_date: String?,
+    val last_air_date: String?,
+    val number_of_seasons: Int?,
+    val number_of_episodes: Int?
 )

--- a/app/src/main/java/com/supernova/data/entities/SeriesWithDetails.kt
+++ b/app/src/main/java/com/supernova/data/entities/SeriesWithDetails.kt
@@ -1,0 +1,10 @@
+package com.supernova.data.entities
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class SeriesWithDetails(
+    @Embedded val series: SeriesEntity,
+    @Relation(parentColumn = "series_id", entityColumn = "tmdb_id")
+    val details: ContentDetailEntity?
+)

--- a/app/src/main/java/com/supernova/network/DataSyncService.kt
+++ b/app/src/main/java/com/supernova/network/DataSyncService.kt
@@ -354,7 +354,13 @@ class DataSyncService(
                     added = stream.added.parseTimestamp(),
                     container_extension = stream.containerExtension.takeIfNotBlank(),
                     custom_sid = stream.customSid.takeIfNotBlank(),
-                    direct_source = stream.directSource.takeIfNotBlank()
+                    direct_source = stream.directSource.takeIfNotBlank(),
+                    backdrop_path = null,
+                    poster_path = null,
+                    overview = null,
+                    genres = null,
+                    runtime = null,
+                    spoken_languages = null
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to parse VOD stream: ${stream.streamId} - ${stream.name}", e)
@@ -435,7 +441,14 @@ class DataSyncService(
                         }
                     },
                     youtube_trailer = stream.youtubeTrailer.takeIfNotBlank(),
-                    episode_run_time = stream.episodeRunTime.takeIfNotBlank()
+                    episode_run_time = stream.episodeRunTime.takeIfNotBlank(),
+                    poster_path = null,
+                    overview = null,
+                    genres = null,
+                    first_air_date = null,
+                    last_air_date = null,
+                    number_of_seasons = null,
+                    number_of_episodes = null
                 )
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to parse series stream: ${stream.seriesId} - ${stream.name}", e)

--- a/app/src/test/java/com/supernova/data/DatabaseRelationshipTest.kt
+++ b/app/src/test/java/com/supernova/data/DatabaseRelationshipTest.kt
@@ -65,7 +65,14 @@ class DatabaseRelationshipTest {
             rating_5based = null,
             backdrop_path = "[\"one.jpg\",\"two.jpg\"]",
             youtube_trailer = null,
-            episode_run_time = null
+            episode_run_time = null,
+            poster_path = null,
+            overview = null,
+            genres = null,
+            first_air_date = null,
+            last_air_date = null,
+            number_of_seasons = null,
+            number_of_episodes = null
         )
 
         seriesDao.insertSeries(series)
@@ -78,7 +85,27 @@ class DatabaseRelationshipTest {
     fun movieCategory_cascadeDeleteRemovesRelations() {
         runBlocking {
         val category = CategoryEntity("movie", 10, "Drama")
-        val movie = MovieEntity(1, null, "Movie", null, null, null, null, null, null, null, null, null, null)
+        val movie = MovieEntity(
+            movie_id = 1,
+            num = null,
+            name = "Movie",
+            title = null,
+            year = null,
+            stream_type = null,
+            stream_icon = null,
+            rating = null,
+            rating_5based = null,
+            added = null,
+            container_extension = null,
+            custom_sid = null,
+            direct_source = null,
+            backdrop_path = null,
+            poster_path = null,
+            overview = null,
+            genres = null,
+            runtime = null,
+            spoken_languages = null
+        )
         db.categoryDao().insertCategory(category)
         movieDao.insertMovie(movie)
         val relation = MovieCategoryEntity(1, "movie", 10)
@@ -123,7 +150,14 @@ class DatabaseRelationshipTest {
             rating_5based = null,
             backdrop_path = "[]",
             youtube_trailer = null,
-            episode_run_time = null
+            episode_run_time = null,
+            poster_path = null,
+            overview = null,
+            genres = null,
+            first_air_date = null,
+            last_air_date = null,
+            number_of_seasons = null,
+            number_of_episodes = null
         )
         db.categoryDao().insertCategory(category)
         seriesDao.insertSeries(series)

--- a/app/src/test/java/com/supernova/data/MigrationTest.kt
+++ b/app/src/test/java/com/supernova/data/MigrationTest.kt
@@ -1,0 +1,25 @@
+package com.supernova.data
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.room.migration.Migration
+import com.supernova.data.database.SupernovaDatabase
+import com.supernova.data.database.MIGRATION_7_8
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertNotNull
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class MigrationTest {
+    @Test
+    fun migrate7To8() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        Room.inMemoryDatabaseBuilder(context, SupernovaDatabase::class.java)
+            .addMigrations(MIGRATION_7_8)
+            .build().apply { close() }
+        assertNotNull(context)
+    }
+}

--- a/app/src/test/java/com/supernova/data/MovieDaoTest.kt
+++ b/app/src/test/java/com/supernova/data/MovieDaoTest.kt
@@ -5,8 +5,10 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.room.Room
 import com.supernova.data.database.SupernovaDatabase
 import com.supernova.data.dao.MovieDao
+import com.supernova.data.entities.ContentDetailEntity
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.first
 import org.junit.After
 import org.junit.Before
 import org.junit.Rule
@@ -56,5 +58,31 @@ class MovieDaoTest {
         dao.insertMovie(movie)
         val loaded = dao.getMovieById(2)
         assertNull(loaded?.stream_type)
+    }
+
+    @Test
+    fun getMovieWithDetails_returnsRelation() = runTest {
+        val movie = TestEntityFactory.movie(id = 3)
+        dao.insertMovie(movie)
+        db.contentDetailDao().insertDetail(
+            ContentDetailEntity(3, "movie", tagline = "tag", status = null, homepage = null, genres = null)
+        )
+        val loaded = dao.getMovieWithDetails(3)
+        assertEquals("tag", loaded?.details?.tagline)
+    }
+
+    @Test
+    fun searchByGenre_filtersCorrectly() = runTest {
+        val movie = TestEntityFactory.movie(id = 4).copy(
+            genres = "Action,Drama",
+            backdrop_path = null,
+            poster_path = null,
+            overview = null,
+            runtime = null,
+            spoken_languages = null
+        )
+        dao.insertMovie(movie)
+        val results = dao.searchByGenre("Action").first()
+        assertEquals(1, results.size)
     }
 }

--- a/app/src/test/java/com/supernova/data/SeriesDaoTest.kt
+++ b/app/src/test/java/com/supernova/data/SeriesDaoTest.kt
@@ -1,0 +1,69 @@
+package com.supernova.data
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.core.app.ApplicationProvider
+import androidx.room.Room
+import com.supernova.data.database.SupernovaDatabase
+import com.supernova.data.dao.SeriesDao
+import com.supernova.data.entities.ContentDetailEntity
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.first
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33])
+class SeriesDaoTest {
+    @get:Rule
+    val rule = InstantTaskExecutorRule()
+
+    private lateinit var db: SupernovaDatabase
+    private lateinit var dao: SeriesDao
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<android.content.Context>()
+        db = Room.inMemoryDatabaseBuilder(context, SupernovaDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        dao = db.seriesDao()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    @Test
+    fun getSeriesWithDetails_returnsRelation() = runTest {
+        val series = TestEntityFactory.series(id = 1)
+        dao.insertSeries(series)
+        db.contentDetailDao().insertDetail(ContentDetailEntity(1, "tv", tagline = "hello", status = null, homepage = null, genres = null))
+        val loaded = dao.getSeriesWithDetails(1)
+        assertEquals("hello", loaded?.details?.tagline)
+    }
+
+    @Test
+    fun getByGenre_filtersCorrectly() = runTest {
+        val series = TestEntityFactory.series(id = 2).copy(
+            genres = "Drama",
+            poster_path = null,
+            overview = null,
+            first_air_date = null,
+            last_air_date = null,
+            number_of_seasons = null,
+            number_of_episodes = null
+        )
+        dao.insertSeries(series)
+        val results = dao.getByGenre("Drama").first()
+        assertEquals(1, results.size)
+    }
+}

--- a/app/src/test/java/com/supernova/data/TestEntityFactory.kt
+++ b/app/src/test/java/com/supernova/data/TestEntityFactory.kt
@@ -35,7 +35,45 @@ object TestEntityFactory {
         added = added,
         container_extension = null,
         custom_sid = null,
-        direct_source = null
+        direct_source = null,
+        backdrop_path = null,
+        poster_path = null,
+        overview = null,
+        genres = null,
+        runtime = null,
+        spoken_languages = null
+    )
+
+    fun series(
+        id: Int = 1,
+        name: String = "Series$id"
+    ) = SeriesEntity(
+        series_id = id,
+        num = id,
+        name = name,
+        title = null,
+        year = null,
+        stream_type = null,
+        cover = null,
+        plot = null,
+        cast = null,
+        director = null,
+        genre = null,
+        release_date = null,
+        releaseDate = null,
+        last_modified = null,
+        rating = null,
+        rating_5based = null,
+        backdrop_path = null,
+        youtube_trailer = null,
+        episode_run_time = null,
+        poster_path = null,
+        overview = null,
+        genres = null,
+        first_air_date = null,
+        last_air_date = null,
+        number_of_seasons = null,
+        number_of_episodes = null
     )
 
     fun liveTv(


### PR DESCRIPTION
## Summary
- extend MovieEntity and SeriesEntity with TMDB fields
- create ContentDetailEntity with DAO and relations
- provide migrations and update database version
- expand TestEntityFactory and DAO tests

## Testing
- `./build.py build` *(fails: `SocketException` when running unit tests)*

------
https://chatgpt.com/codex/tasks/task_e_6878d54ed12c8333aeb2ca14f37588bb