### PR TITLE
Implement BaseRoomTest harness

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,8 @@ androidxEspresso = "3.6.1"
 coreTesting = "2.2.0"
 androidxTestCore = "1.6.1"
 androidxTestRules = "1.6.1"
+sqliteDriver = "2.5.1"
+sqliteJdbc = "3.45.1.0"
 
 [libraries]
 # Core + Compose
@@ -104,6 +106,9 @@ androidx-core-testing = { group = "androidx.arch.core", name = "core-testing", v
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxJunit" }
 androidx-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+androidx-test-core = { group = "androidx.test", name = "core", version.ref = "androidxTestCore" }
+androidx-sqlite-driver = { group = "androidx.sqlite", name = "sqlite-driver", version.ref = "sqliteDriver" }
+sqlite-jdbc = { group = "org.xerial", name = "sqlite-jdbc", version.ref = "sqliteJdbc" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "Supernova"
 include(":app")
+include(":testing-harness")

--- a/testing-harness/build.gradle.kts
+++ b/testing-harness/build.gradle.kts
@@ -1,0 +1,47 @@
+plugins {
+    id("com.android.library")
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.ksp)
+}
+
+android {
+    namespace = "com.supernova.testing"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 26
+        targetSdk = 36
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+    kotlinOptions {
+        jvmTarget = "11"
+    }
+    testOptions {
+        unitTests.isIncludeAndroidResources = true
+    }
+}
+
+dependencies {
+    api(libs.androidx.room.runtime)
+    api(libs.androidx.room.ktx)
+    api(libs.kotlinx.coroutines.test)
+    api(libs.androidx.test.core)
+    api(libs.sqlite.jdbc)
+    api(libs.jupiter.api)
+    ksp(libs.androidx.room.compiler)
+
+    testRuntimeOnly(libs.jupiter.engine)
+    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.mockk)
+    testImplementation(libs.androidx.core.testing)
+    kspTest(libs.androidx.room.compiler)
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/testing-harness/src/main/kotlin/com/supernova/testing/BaseRoomTest.kt
+++ b/testing-harness/src/main/kotlin/com/supernova/testing/BaseRoomTest.kt
@@ -1,0 +1,82 @@
+package com.supernova.testing
+
+import androidx.room.Room
+import androidx.room.RoomDatabase
+import android.app.Application
+import android.content.ContextWrapper
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import java.util.concurrent.Executors
+import kotlin.reflect.KClass
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Base class for Room DAO tests using an in-memory database.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+abstract class BaseRoomTest<T : RoomDatabase> {
+
+    /** Coroutine dispatcher used for database operations. */
+    protected open val dispatcher: TestDispatcher = StandardTestDispatcher()
+    protected val scope = TestScope(dispatcher)
+
+    /** Database class reference used to build the Room database. */
+    protected abstract val databaseClass: KClass<T>
+
+    /** The database instance available to tests. */
+    lateinit var db: T
+        private set
+
+    /**
+     * Override to initialize DAO properties from the created database.
+     */
+    protected abstract fun initDaos(db: T)
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(dispatcher)
+        val context = object : ContextWrapper(Application()) {
+            override fun getSystemService(name: String): Any? = null
+            private fun tmp() = java.io.File(System.getProperty("java.io.tmpdir") ?: ".")
+            override fun getCacheDir() = tmp()
+            override fun getFilesDir() = tmp()
+        }
+        db = Room.inMemoryDatabaseBuilder(
+            context,
+            databaseClass.java
+        )
+            .fallbackToDestructiveMigration()
+            .setQueryExecutor(Executors.newSingleThreadExecutor())
+            .setTransactionExecutor(Executors.newSingleThreadExecutor())
+            .build()
+        initDaos(db)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        db.close()
+        Dispatchers.resetMain()
+    }
+
+    /**
+     * Execute a suspending block within the test scope.
+     */
+    protected fun runBlockingTest(
+        timeout: Duration = 10.seconds,
+        block: suspend TestScope.() -> Unit
+    ) = scope.runTest(timeout) { block() }
+
+    /** Clears all tables in the database. */
+    protected fun clearDatabase() {
+        db.clearAllTables()
+    }
+}

--- a/testing-harness/src/test/kotlin/com/supernova/testing/BaseRoomTestTest.kt
+++ b/testing-harness/src/test/kotlin/com/supernova/testing/BaseRoomTestTest.kt
@@ -1,0 +1,57 @@
+package com.supernova.testing
+
+import androidx.room.Dao
+import androidx.room.Database
+import androidx.room.Entity
+import androidx.room.Insert
+import androidx.room.PrimaryKey
+import androidx.room.Query
+import androidx.room.RoomDatabase
+import kotlin.test.assertEquals
+import org.junit.jupiter.api.Test
+
+@Entity
+data class TestItem(
+    @PrimaryKey val id: Int,
+    val name: String
+)
+
+@Dao
+interface TestDao {
+    @Insert
+    suspend fun insert(item: TestItem)
+
+    @Query("SELECT * FROM TestItem")
+    suspend fun all(): List<TestItem>
+}
+
+@Database(entities = [TestItem::class], version = 1, exportSchema = false)
+abstract class TestDb : RoomDatabase() {
+    abstract fun dao(): TestDao
+}
+
+class BaseRoomTestTest : BaseRoomTest<TestDb>() {
+    lateinit var dao: TestDao
+
+    override val databaseClass = TestDb::class
+
+    override fun initDaos(db: TestDb) {
+        dao = db.dao()
+    }
+
+    @Test
+    fun insertAndQuery() = runBlockingTest {
+        dao.insert(TestItem(1, "hello"))
+        val list = dao.all()
+        assertEquals(1, list.size)
+        assertEquals("hello", list.first().name)
+    }
+
+    @Test
+    fun clearDatabaseRemovesData() = runBlockingTest {
+        dao.insert(TestItem(2, "bye"))
+        clearDatabase()
+        val list = dao.all()
+        assertEquals(0, list.size)
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold testing-harness module with Room database base test
- add simple DAO test verifying setup

## Testing
- `./gradlew :testing-harness:compileDebugKotlin`
- `./gradlew :testing-harness:testDebugUnitTest` *(fails: Method setWriteAheadLoggingEnabled in android.database.sqlite.SQLiteOpenHelper not mocked)*

------
https://chatgpt.com/codex/tasks/task_e_68850d7591e48333961bd373c13d66c1