### PR TITLE
feat: BaseSyncTest harness

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,8 +68,11 @@ coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 # Networking
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
+converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "loggingInterceptor" }
 logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "loggingInterceptor" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
+moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
 
 # Persistence
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "room" }

--- a/testing-harness/build.gradle.kts
+++ b/testing-harness/build.gradle.kts
@@ -4,6 +4,12 @@ plugins {
 }
 
 dependencies {
+    implementation(libs.retrofit)
+    implementation(libs.converter.moshi)
+    implementation(libs.moshi)
+    implementation(libs.moshi.kotlin)
+    implementation(libs.mockwebserver)
+    implementation(libs.jupiter.api)
     testImplementation(libs.jupiter.api)
     testRuntimeOnly(libs.jupiter.engine)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/testing-harness/src/main/kotlin/com/supernova/testing/BaseSyncTest.kt
+++ b/testing-harness/src/main/kotlin/com/supernova/testing/BaseSyncTest.kt
@@ -1,0 +1,57 @@
+package com.supernova.testing
+
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.SocketPolicy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+
+abstract class BaseSyncTest : JsonFixtureLoader() {
+    protected lateinit var server: MockWebServer
+    protected lateinit var retrofit: Retrofit
+    protected lateinit var okHttpClient: OkHttpClient
+
+    @BeforeEach
+    open fun setUp() {
+        server = MockWebServer()
+        server.start()
+        okHttpClient = OkHttpClient.Builder().build()
+        val moshi = Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+        retrofit = Retrofit.Builder()
+            .baseUrl(server.url("/"))
+            .client(okHttpClient)
+            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .build()
+    }
+
+    @AfterEach
+    open fun tearDown() {
+        server.shutdown()
+    }
+
+    protected fun enqueueJsonResponse(fixture: String, code: Int = 200, headers: Map<String, String> = emptyMap()) {
+        val response = MockResponse()
+            .setResponseCode(code)
+            .setBody(fixture)
+        headers.forEach { (k, v) -> response.addHeader(k, v) }
+        server.enqueue(response)
+    }
+
+    protected fun enqueueNetworkFailure() {
+        server.enqueue(MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START))
+    }
+
+    protected fun assertRequest(path: String, method: String = "GET") {
+        val request = server.takeRequest()
+        assertEquals(path, request.path)
+        assertEquals(method, request.method)
+    }
+}

--- a/testing-harness/src/main/kotlin/com/supernova/testing/JsonFixtureLoader.kt
+++ b/testing-harness/src/main/kotlin/com/supernova/testing/JsonFixtureLoader.kt
@@ -1,0 +1,10 @@
+package com.supernova.testing
+
+open class JsonFixtureLoader {
+    protected fun loadJsonFixture(name: String): String {
+        val stream = requireNotNull(javaClass.classLoader?.getResource("fixtures/$name")) {
+            "Fixture $name not found"
+        }
+        return stream.readText()
+    }
+}

--- a/testing-harness/src/test/kotlin/com/supernova/testing/BaseSyncTestTest.kt
+++ b/testing-harness/src/test/kotlin/com/supernova/testing/BaseSyncTestTest.kt
@@ -1,0 +1,51 @@
+package com.supernova.testing
+
+import kotlinx.coroutines.test.runTest
+import retrofit2.http.GET
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import java.io.IOException
+
+class BaseSyncTestTest : BaseSyncTest() {
+    private interface EchoService {
+        @GET("echo")
+        suspend fun echo(): Echo
+    }
+
+    private data class Echo(val message: String)
+
+    private lateinit var service: EchoService
+
+    @BeforeEach
+    override fun setUp() {
+        super.setUp()
+        service = retrofit.create(EchoService::class.java)
+    }
+
+    @Test
+    fun `successful json response`() = runTest {
+        val json = loadJsonFixture("echo.json")
+        enqueueJsonResponse(json)
+
+        val result = service.echo()
+
+        assertEquals("hello", result.message)
+        assertRequest("/echo")
+    }
+
+    @Test
+    fun `http error response`() = runTest {
+        enqueueJsonResponse("{}", code = 404)
+        val response = runCatching { service.echo() }
+        assertTrue(response.isFailure)
+    }
+
+    @Test
+    fun `network failure`() = runTest {
+        enqueueNetworkFailure()
+        assertFailsWith<IOException> { service.echo() }
+    }
+}

--- a/testing-harness/src/test/resources/fixtures/echo.json
+++ b/testing-harness/src/test/resources/fixtures/echo.json
@@ -1,0 +1,3 @@
+{
+  "message": "hello"
+}


### PR DESCRIPTION
## Summary
- add BaseSyncTest and JsonFixtureLoader to testing harness
- configure Retrofit/Moshi/MockWebServer for tests
- add supporting dependencies
- verify BaseSyncTest with sample network scenarios

## Testing
- `./gradlew :testing-harness:test --no-build-cache`
- `./gradlew testDebugUnitTest --no-build-cache`


------
https://chatgpt.com/codex/tasks/task_e_688511e10024833399a795233ed5b368