### PR TITLE
Add DbAssertionHelpers with JDBC-based tests

### DIFF
--- a/testing-harness/build.gradle.kts
+++ b/testing-harness/build.gradle.kts
@@ -1,15 +1,18 @@
 plugins {
     kotlin("jvm")
+    alias(libs.plugins.ksp)
     id("com.supernova.testgate")
 }
 
 dependencies {
+    implementation(libs.kotlin.test)
     testImplementation(libs.jupiter.api)
     testRuntimeOnly(libs.jupiter.engine)
     testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.mockk)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.kotlin.test)
+    testImplementation("org.xerial:sqlite-jdbc:3.45.3.0")
 }
 
 tasks.test {

--- a/testing-harness/src/main/kotlin/com/supernova/testing/DbAssertionHelpers.kt
+++ b/testing-harness/src/main/kotlin/com/supernova/testing/DbAssertionHelpers.kt
@@ -1,0 +1,81 @@
+package com.supernova.testing
+
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Fluent helpers for verifying database state in unit tests.
+ */
+object DbAssertionHelpers {
+
+    fun table(name: String, countProvider: () -> Int) = TableScope(name, countProvider)
+
+    fun <T> entity(actual: T) = EntityScope(actual)
+
+    fun <T> list(actual: List<T>) = ListScope(actual)
+
+    fun <T> search(query: String, actual: List<T>) = SearchScope(query, actual)
+
+    fun <T> cascade(removeParent: () -> Unit, childQuery: () -> T?) =
+        CascadeScope(removeParent, childQuery)
+
+    class TableScope internal constructor(
+        private val name: String,
+        private val countProvider: () -> Int
+    ) {
+        fun hasRowCount(expected: Int): TableScope {
+            val actual = countProvider()
+            assertEquals(
+                expected,
+                actual,
+                "Table '$name' expected $expected rows but had $actual"
+            )
+            return this
+        }
+
+        fun isEmpty(): TableScope = hasRowCount(0)
+
+        fun isPopulated(): TableScope {
+            val actual = countProvider()
+            assertTrue(actual > 0, "Expected table '$name' to be populated")
+            return this
+        }
+    }
+
+    class EntityScope<T> internal constructor(private val actual: T) {
+        fun isEqualTo(expected: T): EntityScope<T> {
+            assertEquals(expected, actual)
+            return this
+        }
+    }
+
+    class ListScope<T> internal constructor(private val actual: List<T>) {
+        fun isEqualTo(expected: List<T>): ListScope<T> {
+            assertEquals(expected, actual)
+            return this
+        }
+    }
+
+    class SearchScope<T> internal constructor(
+        private val query: String,
+        private val actual: List<T>
+    ) {
+        fun matches(expected: List<T>): SearchScope<T> {
+            assertEquals(expected, actual, "Search '$query' results mismatch")
+            return this
+        }
+    }
+
+    class CascadeScope<T> internal constructor(
+        private val removeParent: () -> Unit,
+        private val childQuery: () -> T?
+    ) {
+        fun cascades(): CascadeScope<T> {
+            removeParent()
+            val child = childQuery()
+            assertNull(child, "Cascade delete failed")
+            return this
+        }
+    }
+}

--- a/testing-harness/src/test/kotlin/com/supernova/testing/DbAssertionHelpersTest.kt
+++ b/testing-harness/src/test/kotlin/com/supernova/testing/DbAssertionHelpersTest.kt
@@ -1,0 +1,169 @@
+package com.supernova.testing
+
+import kotlinx.coroutines.test.runTest
+import java.sql.Connection
+import java.sql.DriverManager
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DbAssertionHelpersTest : TestEntityFactory() {
+
+    private fun createDb(): Connection {
+        val conn = DriverManager.getConnection("jdbc:sqlite::memory:")
+        conn.createStatement().use { stmt ->
+            stmt.execute("PRAGMA foreign_keys=ON")
+            stmt.execute("CREATE TABLE categories(id INTEGER PRIMARY KEY, name TEXT)")
+            stmt.execute(
+                """CREATE TABLE streams(
+                    id INTEGER PRIMARY KEY,
+                    title TEXT,
+                    categoryId INTEGER,
+                    streamType TEXT,
+                    isLive INTEGER,
+                    number INTEGER,
+                    FOREIGN KEY(categoryId) REFERENCES categories(id) ON DELETE CASCADE
+                )"""
+            )
+            stmt.execute("CREATE VIRTUAL TABLE stream_search USING fts4(content='streams', title)")
+            stmt.execute("CREATE TRIGGER streams_ai AFTER INSERT ON streams BEGIN INSERT INTO stream_search(rowid,title) VALUES (new.rowid,new.title); END")
+            stmt.execute("CREATE TRIGGER streams_ad AFTER DELETE ON streams BEGIN DELETE FROM stream_search WHERE rowid = old.rowid; END")
+        }
+        return conn
+    }
+
+    private fun Connection.count(table: String): Int {
+        createStatement().use { stmt ->
+            val rs = stmt.executeQuery("SELECT COUNT(*) FROM $table")
+            return if (rs.next()) rs.getInt(1) else 0
+        }
+    }
+
+    private fun Connection.insertCategory(category: Category) {
+        prepareStatement("INSERT INTO categories(id,name) VALUES (?,?)").use {
+            it.setLong(1, category.id)
+            it.setString(2, category.name)
+            it.executeUpdate()
+        }
+    }
+
+    private fun Connection.insertStream(stream: Stream) {
+        prepareStatement(
+            "INSERT INTO streams(id,title,categoryId,streamType,isLive,number) VALUES (?,?,?,?,?,?)"
+        ).use {
+            it.setLong(1, stream.id)
+            it.setString(2, stream.title)
+            it.setLong(3, stream.categoryId)
+            it.setString(4, stream.streamType)
+            it.setInt(5, if (stream.isLive) 1 else 0)
+            it.setInt(6, stream.number)
+            it.executeUpdate()
+        }
+    }
+
+    private fun Connection.queryStream(id: Long): Stream? {
+        prepareStatement(
+            "SELECT id,title,categoryId,streamType,isLive,number FROM streams WHERE id=?"
+        ).use {
+            it.setLong(1, id)
+            val rs = it.executeQuery()
+            return if (rs.next()) {
+                Stream(
+                    rs.getLong(1),
+                    rs.getString(2),
+                    rs.getLong(3),
+                    rs.getString(4),
+                    rs.getInt(5) == 1,
+                    rs.getInt(6)
+                )
+            } else null
+        }
+    }
+
+    private fun Connection.queryAllStreams(): List<Stream> {
+        createStatement().use { stmt ->
+            val rs = stmt.executeQuery(
+                "SELECT id,title,categoryId,streamType,isLive,number FROM streams ORDER BY id"
+            )
+            val list = mutableListOf<Stream>()
+            while (rs.next()) {
+                list += Stream(
+                    rs.getLong(1),
+                    rs.getString(2),
+                    rs.getLong(3),
+                    rs.getString(4),
+                    rs.getInt(5) == 1,
+                    rs.getInt(6)
+                )
+            }
+            return list
+        }
+    }
+
+    private fun Connection.searchStreams(q: String): List<Stream> {
+        prepareStatement("SELECT s.id,s.title,s.categoryId,s.streamType,s.isLive,s.number FROM streams s JOIN stream_search ON s.id=stream_search.rowid WHERE stream_search MATCH ? ORDER BY s.id").use {
+            it.setString(1, q)
+            val rs = it.executeQuery()
+            val list = mutableListOf<Stream>()
+            while (rs.next()) {
+                list += Stream(rs.getLong(1), rs.getString(2), rs.getLong(3), rs.getString(4), rs.getInt(5) == 1, rs.getInt(6))
+            }
+            return list
+        }
+    }
+
+    private fun loadSearchFixture(): String =
+        javaClass.classLoader!!.getResource("fixtures/search_results.json")!!.readText()
+
+    @Test
+    fun rowCount_entity_list_assertions() = runTest {
+        val db = createDb()
+        val category = TestEntityFactory.category()
+        val stream = TestEntityFactory.stream(categoryId = category.id)
+        db.insertCategory(category)
+        db.insertStream(stream)
+
+        DbAssertionHelpers.table("streams") { db.count("streams") }
+            .hasRowCount(1)
+            .isPopulated()
+
+        val fetched = db.queryStream(stream.id)
+        DbAssertionHelpers.entity(fetched).isEqualTo(stream)
+
+        val list = db.queryAllStreams()
+        DbAssertionHelpers.list(list).isEqualTo(listOf(stream))
+
+        db.close()
+    }
+
+    @Test
+    fun search_state_and_cascade() = runTest {
+        val db = createDb()
+        val category = TestEntityFactory.category()
+        val stream1 = TestEntityFactory.stream(id = 1L, title = "Alpha", categoryId = category.id)
+        val stream2 = TestEntityFactory.stream(id = 2L, title = "Beta", categoryId = category.id)
+        db.insertCategory(category)
+        db.insertStream(stream1)
+        db.insertStream(stream2)
+
+        val searchResults = db.searchStreams("Alpha")
+        val fixture = loadSearchFixture()
+        assertTrue(fixture.isNotEmpty())
+        DbAssertionHelpers.search("Alpha", searchResults).matches(listOf(stream1))
+
+        DbAssertionHelpers.table("streams") { db.count("streams") }.isPopulated()
+
+        DbAssertionHelpers.cascade(
+            removeParent = {
+                db.prepareStatement("DELETE FROM categories WHERE id=?").use {
+                    it.setLong(1, category.id)
+                    it.executeUpdate()
+                }
+            },
+            childQuery = { db.queryStream(stream1.id) }
+        ).cascades()
+
+        DbAssertionHelpers.table("streams") { db.count("streams") }.isEmpty()
+
+        db.close()
+    }
+}

--- a/testing-harness/src/test/resources/fixtures/search_results.json
+++ b/testing-harness/src/test/resources/fixtures/search_results.json
@@ -1,0 +1,1 @@
+{"query":"Alpha","results":["Alpha"]}


### PR DESCRIPTION
## Summary
- implement `DbAssertionHelpers` for fluent database assertions
- cover helpers with unit tests using in-memory SQLite and FTS4
- add new search fixture
- configure build for kotlin.test and sqlite-jdbc

## Testing
- `./gradlew :testing-harness:test --no-build-cache`

------
https://chatgpt.com/codex/tasks/task_e_688511ce22e48333af842d2bf1a56e3f