### PR TITLE
Provider API Service Implementation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,6 +103,10 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.androidx.room.testing)
     testImplementation(libs.androidx.core.testing)
+    testImplementation(project(":testing-harness"))
+    testImplementation(libs.serialization)
+    testImplementation(libs.kotlin.test)
+    testImplementation(project(":testing-harness"))
 
     androidTestImplementation(libs.androidx.test.core)
     androidTestImplementation(libs.androidx.test.rules)

--- a/app/src/main/kotlin/com/supernova/network/ProviderService.kt
+++ b/app/src/main/kotlin/com/supernova/network/ProviderService.kt
@@ -1,0 +1,36 @@
+package com.supernova.network
+
+import com.supernova.network.dto.CategoryDto
+import com.supernova.network.dto.StreamDto
+import com.supernova.network.dto.ProgramDto
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+/**
+ * Retrofit service for XC API provider endpoints.
+ */
+interface ProviderService {
+    @GET("player_api.php")
+    suspend fun getCategories(
+        @Query("action") action: String = "get_live_categories",
+        @Query("username") username: String,
+        @Query("password") password: String
+    ): List<CategoryDto>
+
+    @GET("player_api.php")
+    suspend fun getStreams(
+        @Query("action") action: String = "get_live_streams",
+        @Query("category_id") categoryId: Int,
+        @Query("username") username: String,
+        @Query("password") password: String
+    ): List<StreamDto>
+
+    @GET("player_api.php")
+    suspend fun getPrograms(
+        @Query("action") action: String = "get_short_epg",
+        @Query("stream_id") streamId: Int,
+        @Query("limit") limit: Int = 1,
+        @Query("username") username: String,
+        @Query("password") password: String
+    ): List<ProgramDto>
+}

--- a/app/src/main/kotlin/com/supernova/network/dto/CategoryDto.kt
+++ b/app/src/main/kotlin/com/supernova/network/dto/CategoryDto.kt
@@ -1,0 +1,9 @@
+package com.supernova.network.dto
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class CategoryDto(
+    val category_id: Int,
+    val category_name: String
+)

--- a/app/src/main/kotlin/com/supernova/network/dto/ProgramDto.kt
+++ b/app/src/main/kotlin/com/supernova/network/dto/ProgramDto.kt
@@ -1,0 +1,13 @@
+package com.supernova.network.dto
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class ProgramDto(
+    val id: Int,
+    val epg_channel_id: Int,
+    val start: String,
+    val end: String,
+    val title: String,
+    val description: String
+)

--- a/app/src/main/kotlin/com/supernova/network/dto/StreamDto.kt
+++ b/app/src/main/kotlin/com/supernova/network/dto/StreamDto.kt
@@ -1,0 +1,11 @@
+package com.supernova.network.dto
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class StreamDto(
+    val stream_id: Int,
+    val name: String,
+    val category_id: Int,
+    val stream_type: String
+)

--- a/app/src/test/kotlin/com/supernova/network/ProviderServiceTest.kt
+++ b/app/src/test/kotlin/com/supernova/network/ProviderServiceTest.kt
@@ -1,0 +1,69 @@
+package com.supernova.network
+
+import com.supernova.testing.BaseSyncTest
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import kotlinx.serialization.json.JsonElement
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+private object MockWebServerExtensions {
+    fun MockWebServer.enqueueJson(
+        json: String,
+        code: Int = 200
+    ) {
+        enqueue(MockResponse().setResponseCode(code).setBody(json))
+    }
+}
+
+class ProviderServiceTest : BaseSyncTest() {
+    private lateinit var service: ProviderService
+    private lateinit var fixture: Map<String, JsonElement>
+
+    @BeforeEach
+    override fun setUp() {
+        super.setUp()
+        service = retrofit.create(ProviderService::class.java)
+    }
+
+    @Test
+    fun `get categories parses response`() = runTest {
+        fixture = loadAsMap("provider_api_test.json")
+        val json = fixture["categories"].toString()
+        with(MockWebServerExtensions) { server.enqueueJson(json) }
+
+        val result = service.getCategories(username = "u", password = "p")
+
+        assertEquals(1, result.size)
+        assertEquals("News", result.first().category_name)
+        assertRequest("/player_api.php?action=get_live_categories&username=u&password=p")
+    }
+
+    @Test
+    fun `get streams parses response`() = runTest {
+        fixture = loadAsMap("provider_api_test.json")
+        val json = fixture["streams"].toString()
+        with(MockWebServerExtensions) { server.enqueueJson(json) }
+
+        val result = service.getStreams(categoryId = 1, username = "u", password = "p")
+
+        assertEquals(1, result.size)
+        assertEquals(10, result.first().stream_id)
+        assertRequest("/player_api.php?action=get_live_streams&category_id=1&username=u&password=p")
+    }
+
+    @Test
+    fun `get programs parses response`() = runTest {
+        fixture = loadAsMap("provider_api_test.json")
+        val json = fixture["programs"].toString()
+        with(MockWebServerExtensions) { server.enqueueJson(json) }
+
+        val result = service.getPrograms(streamId = 10, username = "u", password = "p")
+
+        assertEquals(1, result.size)
+        assertEquals("Morning News", result.first().title)
+        assertRequest("/player_api.php?action=get_short_epg&stream_id=10&limit=1&username=u&password=p")
+    }
+}

--- a/app/src/test/resources/fixtures/provider_api_test.json
+++ b/app/src/test/resources/fixtures/provider_api_test.json
@@ -1,0 +1,18 @@
+{
+  "categories": [
+    {"category_id": 1, "category_name": "News"}
+  ],
+  "streams": [
+    {"stream_id": 10, "name": "CNN", "category_id": 1, "stream_type": "live"}
+  ],
+  "programs": [
+    {
+      "id": 101,
+      "epg_channel_id": 10,
+      "start": "2024-01-01 10:00:00",
+      "end": "2024-01-01 11:00:00",
+      "title": "Morning News",
+      "description": "Daily news"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- implement ProviderService Retrofit interface with XC API endpoints
- add DTO models for categories, streams and programs
- integrate test harness for provider service using MockWebServer
- add test fixture and unit tests verifying endpoint behavior

## Testing
- `./gradlew :app:test --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6886e24828e88333ba72b3f5c00213bb