### PR TITLE
Quick rescue patch for BaseRoomTest

### DIFF
--- a/testing-harness/src/main/kotlin/com/supernova/testing/BaseRoomTest.kt
+++ b/testing-harness/src/main/kotlin/com/supernova/testing/BaseRoomTest.kt
@@ -23,7 +23,9 @@ import androidx.test.core.app.ApplicationProvider
  * Base class for Room DAO tests using an in-memory database.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-abstract class BaseRoomTest<T : RoomDatabase> {
+abstract class BaseRoomTest<T : RoomDatabase>(
+    private val context: Context = ApplicationProvider.getApplicationContext()
+) {
 
     /** Coroutine dispatcher used for database operations. */
     protected open val dispatcher: TestDispatcher = StandardTestDispatcher()
@@ -44,7 +46,6 @@ abstract class BaseRoomTest<T : RoomDatabase> {
     @BeforeEach
     fun setUp() {
         Dispatchers.setMain(dispatcher)
-        val context = ApplicationProvider.getApplicationContext<Context>()
         db = Room.inMemoryDatabaseBuilder(
             context,
             databaseClass.java

--- a/testing-harness/src/test/kotlin/com/supernova/testing/BaseRoomTestTest.kt
+++ b/testing-harness/src/test/kotlin/com/supernova/testing/BaseRoomTestTest.kt
@@ -7,6 +7,8 @@ import androidx.room.Insert
 import androidx.room.PrimaryKey
 import androidx.room.Query
 import androidx.room.RoomDatabase
+import android.content.Context
+import io.mockk.mockk
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -30,7 +32,8 @@ abstract class TestDb : RoomDatabase() {
     abstract fun dao(): TestDao
 }
 
-class BaseRoomTestTest : BaseRoomTest<TestDb>() {
+private val fakeCtx = mockk<Context>(relaxed = true)
+class BaseRoomTestTest : BaseRoomTest<TestDb>(fakeCtx) {
     lateinit var dao: TestDao
 
     override val databaseClass = TestDb::class


### PR DESCRIPTION
## Summary
- support dependency injection in `BaseRoomTest`
- use a mocked `Context` in `BaseRoomTestTest`

## Testing
- `./gradlew test --console=plain --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68883a49e18083338924a21b1f0633ba