### PR TITLE
Enable remote build cache

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.caching.http.HttpBuildCache
+
 pluginManagement {
     repositories {
         google {
@@ -16,6 +18,21 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+    }
+}
+
+
+buildCache {
+    local {
+        isEnabled = true
+    }
+    remote<HttpBuildCache> {
+        url = uri("https://aa44b0d9c4503975b23eae50165d0e0f.r2.cloudflarestorage.com/cache")
+        isPush = System.getenv("CI") != null
+        credentials {
+            username = System.getenv("GRADLE_CACHE_USER") ?: ""
+            password = System.getenv("GRADLE_CACHE_PASSWORD") ?: System.getenv("GRADLE_CACHE_PASS") ?: ""
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- enable remote build cache in `settings.gradle.kts`

## Testing
- `./gradlew test --no-daemon --no-build-cache`


------
https://chatgpt.com/codex/tasks/task_e_68883fbe21d4833386ba8aac435514bd