### PR TITLE
Implement RoomProgramRepository

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -110,6 +110,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.androidx.room.testing)
     testImplementation(libs.androidx.core.testing)
+    testImplementation(libs.androidx.test.core)
     testImplementation(project(":testing-harness"))
     testImplementation(libs.serialization)
     testImplementation(libs.kotlin.test)

--- a/app/src/main/kotlin/com/supernova/domain/mapper/EntityToDomain.kt
+++ b/app/src/main/kotlin/com/supernova/domain/mapper/EntityToDomain.kt
@@ -1,0 +1,15 @@
+package com.supernova.domain.mapper
+
+import com.supernova.data.ProgramEntity
+import com.supernova.domain.model.Program
+import java.time.Instant
+import java.time.ZoneOffset
+
+fun ProgramEntity.toDomain(): Program = Program(
+    id = id,
+    epgChannelId = epgChannelId,
+    start = Instant.ofEpochMilli(start).atZone(ZoneOffset.UTC).toLocalDateTime(),
+    end = Instant.ofEpochMilli(end).atZone(ZoneOffset.UTC).toLocalDateTime(),
+    title = title,
+    description = description
+)

--- a/app/src/main/kotlin/com/supernova/domain/mapper/Mappers.kt
+++ b/app/src/main/kotlin/com/supernova/domain/mapper/Mappers.kt
@@ -13,15 +13,15 @@ import java.time.format.DateTimeParseException
 private val PROGRAM_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
 
 fun CategoryDto.toDomain(): Category = Category(
-    id = category_id,
-    name = category_name
+    id = categoryId,
+    name = categoryName
 )
 
 fun StreamDto.toDomain(): Stream = Stream(
-    id = stream_id,
+    id = streamId,
     name = name,
-    categoryId = category_id,
-    streamType = stream_type
+    categoryId = categoryId,
+    streamType = streamType
 )
 
 fun ProgramDto.toDomain(): Program {
@@ -29,7 +29,7 @@ fun ProgramDto.toDomain(): Program {
     val endTime = parseDate(end)
     return Program(
         id = id,
-        epgChannelId = epg_channel_id,
+        epgChannelId = epgChannelId,
         start = startTime,
         end = endTime,
         title = title,

--- a/app/src/main/kotlin/com/supernova/domain/repository/ProgramRepository.kt
+++ b/app/src/main/kotlin/com/supernova/domain/repository/ProgramRepository.kt
@@ -1,0 +1,9 @@
+package com.supernova.domain.repository
+
+import com.supernova.domain.model.Program
+import kotlinx.coroutines.flow.Flow
+
+/** Accessor for program data. */
+interface ProgramRepository {
+    fun nowPlaying(streamId: Int): Flow<Program?>
+}

--- a/app/src/main/kotlin/com/supernova/domain/repository/RoomProgramRepository.kt
+++ b/app/src/main/kotlin/com/supernova/domain/repository/RoomProgramRepository.kt
@@ -1,0 +1,21 @@
+package com.supernova.domain.repository
+
+import com.supernova.data.ProgramDao
+import com.supernova.domain.model.Program
+import com.supernova.domain.mapper.toDomain
+import com.supernova.util.Clock
+import com.supernova.util.SystemClock
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+/** Room-backed implementation of [ProgramRepository]. */
+class RoomProgramRepository(
+    private val dao: ProgramDao,
+    private val clock: Clock = SystemClock
+) : ProgramRepository {
+
+    override fun nowPlaying(streamId: Int): Flow<Program?> = flow {
+        val now = clock.currentTimeMillis()
+        emit(dao.nowPlaying(streamId, now)?.toDomain())
+    }
+}

--- a/app/src/main/kotlin/com/supernova/util/Clock.kt
+++ b/app/src/main/kotlin/com/supernova/util/Clock.kt
@@ -1,0 +1,10 @@
+package com.supernova.util
+
+/** Simple abstraction over time retrieval for testability. */
+fun interface Clock {
+    fun currentTimeMillis(): Long
+}
+
+object SystemClock : Clock {
+    override fun currentTimeMillis(): Long = System.currentTimeMillis()
+}

--- a/app/src/test/kotlin/com/supernova/domain/mapper/MappersTest.kt
+++ b/app/src/test/kotlin/com/supernova/domain/mapper/MappersTest.kt
@@ -21,8 +21,8 @@ class MappersTest : TestEntityFactory() {
         val fixture = loader.loadAsMap("mappers_fixture.json")
         val obj = fixture["category"]!!.jsonObject
         val dto = CategoryDto(
-            category_id = obj["category_id"]!!.jsonPrimitive.int,
-            category_name = obj["category_name"]!!.jsonPrimitive.content
+            categoryId = obj["category_id"]!!.jsonPrimitive.int,
+            categoryName = obj["category_name"]!!.jsonPrimitive.content
         )
         val domain = dto.toDomain()
         assertEquals(1, domain.id)
@@ -34,10 +34,10 @@ class MappersTest : TestEntityFactory() {
         val fixture = loader.loadAsMap("mappers_fixture.json")
         val obj = fixture["stream"]!!.jsonObject
         val dto = StreamDto(
-            stream_id = obj["stream_id"]!!.jsonPrimitive.int,
+            streamId = obj["stream_id"]!!.jsonPrimitive.int,
             name = obj["name"]!!.jsonPrimitive.content,
-            category_id = obj["category_id"]!!.jsonPrimitive.int,
-            stream_type = obj["stream_type"]!!.jsonPrimitive.content
+            categoryId = obj["category_id"]!!.jsonPrimitive.int,
+            streamType = obj["stream_type"]!!.jsonPrimitive.content
         )
         val domain = dto.toDomain()
         assertEquals(10, domain.id)
@@ -52,7 +52,7 @@ class MappersTest : TestEntityFactory() {
         val obj = fixture["program"]!!.jsonObject
         val dto = ProgramDto(
             id = obj["id"]!!.jsonPrimitive.int,
-            epg_channel_id = obj["epg_channel_id"]!!.jsonPrimitive.int,
+            epgChannelId = obj["epg_channel_id"]!!.jsonPrimitive.int,
             start = obj["start"]!!.jsonPrimitive.content,
             end = obj["end"]!!.jsonPrimitive.content,
             title = obj["title"]!!.jsonPrimitive.content,
@@ -68,7 +68,7 @@ class MappersTest : TestEntityFactory() {
     fun `program dto maps with invalid date uses min`() = runTest {
         val dto = ProgramDto(
             id = 2,
-            epg_channel_id = 5,
+            epgChannelId = 5,
             start = "bad", end = "bad",
             title = "Bad", description = "Bad"
         )

--- a/app/src/test/kotlin/com/supernova/domain/repository/RoomProgramRepositoryTest.kt
+++ b/app/src/test/kotlin/com/supernova/domain/repository/RoomProgramRepositoryTest.kt
@@ -1,0 +1,90 @@
+package com.supernova.domain.repository
+
+import com.supernova.data.ProgramDao
+import com.supernova.data.ProgramEntity
+import com.supernova.data.SupernovaDatabase
+import com.supernova.testing.BaseRoomTest
+import com.supernova.testing.JsonFixtureLoader
+import kotlinx.coroutines.flow.single
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.long
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+private val fakeCtx = mockk<android.content.Context>(relaxed = true) {
+    every { applicationContext } returns this
+    every { filesDir } returns java.io.File("/tmp")
+    every { noBackupFilesDir } returns java.io.File("/tmp")
+    every { cacheDir } returns java.io.File("/tmp")
+    every { getDatabasePath(any()) } returns java.io.File("/tmp/db")
+}
+
+class RoomProgramRepositoryTest : BaseRoomTest<SupernovaDatabase>(fakeCtx) {
+    override val databaseClass = SupernovaDatabase::class
+
+    private lateinit var dao: ProgramDao
+    private lateinit var repository: ProgramRepository
+    private val clock = TestClock()
+    private val loader = JsonFixtureLoader()
+
+    override fun initDaos(db: SupernovaDatabase) {
+        dao = db.programDao()
+        repository = RoomProgramRepository(dao, clock)
+    }
+
+    @Test
+    fun `returns null when no matching program`() = runBlockingTest {
+        clock.now = 1000L
+        dao.insert(
+            ProgramEntity(1, 1, 0, 500, "Old", "past")
+        )
+        val result = repository.nowPlaying(1).single()
+        assertNull(result)
+    }
+
+    @Test
+    fun `returns current program`() = runBlockingTest {
+        val fixture = loader.loadAsMap("program_fixture.json")
+        val obj = fixture["program"]!!.jsonObject
+        val start = obj["start"]!!.jsonPrimitive.long
+        val end = obj["end"]!!.jsonPrimitive.long
+        val entity = ProgramEntity(
+            id = obj["id"]!!.jsonPrimitive.int,
+            epgChannelId = obj["epg_channel_id"]!!.jsonPrimitive.int,
+            start = start,
+            end = end,
+            title = obj["title"]!!.jsonPrimitive.content,
+            description = obj["description"]!!.jsonPrimitive.content
+        )
+        dao.insert(entity)
+        clock.now = start + 100
+        val result = repository.nowPlaying(entity.epgChannelId).single()!!
+        assertEquals(entity.id, result.id)
+        assertEquals(
+            Instant.ofEpochMilli(start).atZone(ZoneOffset.UTC).toLocalDateTime(),
+            result.start
+        )
+    }
+
+    @Test
+    fun `picks latest start on overlap`() = runBlockingTest {
+        clock.now = 1500L
+        val early = ProgramEntity(1, 1, 500, 2000, "A", "")
+        val late = ProgramEntity(2, 1, 1000, 2000, "B", "")
+        dao.insert(early)
+        dao.insert(late)
+        val result = repository.nowPlaying(1).single()!!
+        assertEquals(late.id, result.id)
+    }
+
+    private class TestClock(var now: Long = 0L) : com.supernova.util.Clock {
+        override fun currentTimeMillis(): Long = now
+    }
+}

--- a/app/src/test/kotlin/com/supernova/network/ProviderServiceTest.kt
+++ b/app/src/test/kotlin/com/supernova/network/ProviderServiceTest.kt
@@ -37,7 +37,7 @@ class ProviderServiceTest : BaseSyncTest() {
         val result = service.getCategories(username = "u", password = "p")
 
         assertEquals(1, result.size)
-        assertEquals("News", result.first().category_name)
+        assertEquals("News", result.first().categoryName)
         assertRequest("/player_api.php?action=get_live_categories&username=u&password=p")
     }
 
@@ -50,7 +50,7 @@ class ProviderServiceTest : BaseSyncTest() {
         val result = service.getStreams(categoryId = 1, username = "u", password = "p")
 
         assertEquals(1, result.size)
-        assertEquals(10, result.first().stream_id)
+        assertEquals(10, result.first().streamId)
         assertRequest("/player_api.php?action=get_live_streams&category_id=1&username=u&password=p")
     }
 

--- a/app/src/test/resources/fixtures/program_fixture.json
+++ b/app/src/test/resources/fixtures/program_fixture.json
@@ -1,0 +1,10 @@
+{
+  "program": {
+    "id": 5,
+    "epg_channel_id": 1,
+    "start": 1000,
+    "end": 2000,
+    "title": "Test Program",
+    "description": "Fixture program"
+  }
+}

--- a/data/src/main/kotlin/com/supernova/data/ProgramDao.kt
+++ b/data/src/main/kotlin/com/supernova/data/ProgramDao.kt
@@ -1,11 +1,24 @@
 package com.supernova.data
 
 import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 
-/** Placeholder DAO for programs. */
+/** DAO for program lookups. */
 @Dao
 interface ProgramDao {
-    @Query("SELECT 1")
-    suspend fun noop(): Int
+    @Query(
+        """
+            SELECT * FROM program
+            WHERE epg_channel_id = :streamId
+              AND start <= :now AND end > :now
+            ORDER BY start DESC
+            LIMIT 1
+        """
+    )
+    suspend fun nowPlaying(streamId: Int, now: Long): ProgramEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: ProgramEntity)
 }

--- a/data/src/main/kotlin/com/supernova/data/ProgramEntity.kt
+++ b/data/src/main/kotlin/com/supernova/data/ProgramEntity.kt
@@ -1,9 +1,15 @@
 package com.supernova.data
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
 @Entity(tableName = "program")
-internal data class ProgramEntity(
-    @PrimaryKey val id: Int = 0
+data class ProgramEntity(
+    @PrimaryKey val id: Int,
+    @ColumnInfo(name = "epg_channel_id") val epgChannelId: Int,
+    @ColumnInfo(name = "start") val start: Long,
+    @ColumnInfo(name = "end") val end: Long,
+    val title: String,
+    val description: String
 )

--- a/data/src/main/kotlin/com/supernova/data/SupernovaDatabase.kt
+++ b/data/src/main/kotlin/com/supernova/data/SupernovaDatabase.kt
@@ -6,7 +6,11 @@ import androidx.room.RoomDatabase
 /**
  * Empty Room database to be populated in later tasks.
  */
-@Database(version = 1, entities = [PlaceholderEntity::class], exportSchema = false)
+@Database(
+    version = 1,
+    entities = [PlaceholderEntity::class, ProgramEntity::class],
+    exportSchema = false
+)
 abstract class SupernovaDatabase : RoomDatabase() {
     abstract fun categoryDao(): CategoryDao
     abstract fun streamDao(): StreamDao


### PR DESCRIPTION
## Summary
- flesh out `ProgramEntity` with fields
- add `nowPlaying` query in `ProgramDao`
- include `ProgramEntity` in `SupernovaDatabase`
- expose program repository with time-based lookup
- provide `Clock` and mapping utilities
- create unit tests and JSON fixture
- adjust test harness for Room journal mode

## Testing
- `./gradlew :app:testDebugUnitTest --tests "com.supernova.domain.repository.RoomProgramRepositoryTest"` *(fails: Method setWriteAheadLoggingEnabled not mocked)*


------
https://chatgpt.com/codex/tasks/task_e_6888d6dbc0b8833398faa5124fca2afe