### PR TITLE
task: ticket for OneShotSyncWorker compile failure

### DIFF
--- a/docs/issues/qaGate_failure.md
+++ b/docs/issues/qaGate_failure.md
@@ -1,0 +1,6 @@
+# qaGate failure: unresolvable after 4 attempts
+
+Implementation of OneShotSyncWorker repeatedly failed due to unresolved compile errors with missing dependencies. After four retries, the build cannot pass the test gate. Issue created for escalation.
+
+GitHub issue: https://github.com/dorphalsig/Supernova/issues/33
+


### PR DESCRIPTION
## Summary
- log the compile errors after 4 attempts in `qaGate_failure.md`
- GitHub issue opened: [#33](https://github.com/dorphalsig/Supernova/issues/33)

## Testing
- No tests run due to unresolved compile errors

------
https://chatgpt.com/codex/tasks/task_e_6888d70400a88333bcca582a536ff005